### PR TITLE
Documentation Fixes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ about MeTA!
 - develop: [![Build
   Status](https://travis-ci.org/meta-toolkit/meta.svg?branch=develop)](https://travis-ci.org/meta-toolkit/meta)
 
+### Outline
 - [Intro](#intro)
     - [Documentation](#documentation)
     - [Tutorials](#tutorials)

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ about MeTA!
 - develop: [![Build
   Status](https://travis-ci.org/meta-toolkit/meta.svg?branch=develop)](https://travis-ci.org/meta-toolkit/meta)
 
-### Outline
+# Outline
 - [Intro](#intro)
     - [Documentation](#documentation)
     - [Tutorials](#tutorials)
@@ -19,7 +19,7 @@ about MeTA!
     - [Arch Linux](#arch-linux-build-guide)
     - [Generic Setup Notes](#generic-setup-notes)
 
-## Intro
+# Intro
 
 MeTA is a modern C++ data sciences toolkit featuring
 
@@ -35,18 +35,18 @@ MeTA is a modern C++ data sciences toolkit featuring
  - UTF8 support for analysis on various languages
  - multithreaded algorithms
 
-### Documentation
+## Documentation
 
 Doxygen documentation can be found [here][doxygen].
 
-### Tutorials
+## Tutorials
 
 We have walkthroughs for a few different parts of MeTA on the
 [MeTA homepage][meta-website].
 
-## Project setup
+# Project setup
 
-### Mac OS X Build Guide
+## Mac OS X Build Guide
 Mac OS X 10.6 or higher is required. You may have success with 10.5, but
 this is not tested.
 
@@ -93,7 +93,7 @@ ctest --output-on-failure
 If everything passes, congratulations! MeTA seems to be working on your
 system.
 
-### Ubuntu Build Guide
+## Ubuntu Build Guide
 
 The directions here depend greatly on your installed version of Ubuntu. To
 check what version you are on, run the following command:
@@ -110,7 +110,7 @@ version is less than 12.04 LTS, your operating system is not supported
 (even by your vendor) and you should upgrade to at least 12.04 LTS (or
 14.04 LTS, if possible).
 
-#### Ubuntu 12.04 LTS Build Guide
+### Ubuntu 12.04 LTS Build Guide
 Building on Ubuntu 12.04 LTS requires more work than its more up-to-date
 14.04 sister, but it can be done relatively easily. You will, however, need
 to install a newer C++ compiler from a ppa, and switch to it in order to
@@ -197,7 +197,7 @@ You can now test the system by running the following command:
 If everything passes, congratulations! MeTA seems to be working on your
 system.
 
-#### Ubuntu 14.04 LTS Build Guide
+### Ubuntu 14.04 LTS Build Guide
 Ubuntu 14.04 has a recent enough GCC for building MeTA, but we'll need to
 add a ppa for a more recent version of CMake.
 
@@ -277,7 +277,7 @@ ctest --output-on-failure
 If everything passes, congratulations! MeTA seems to be working on your
 system.
 
-### Arch Linux Build Guide
+## Arch Linux Build Guide
 Arch Linux consistently has the most up to date packages due to its rolling
 release setup, so it's often the easiest platform to get set up on.
 
@@ -317,7 +317,7 @@ ctest --output-on-failure
 If everything passes, congratulations! MeTA seems to be working on your
 system.
 
-### Generic Setup Notes
+## Generic Setup Notes
 
  - There are rules for clean, tidy, and doc. **After you run the cmake command
    once, you will be able to just run `make` as usual** when you're

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@ about MeTA!
     - [Mac OS X](#mac-os-x-build-guide)
     - [Ubuntu](#ubuntu-build-guide)
     - [Arch Linux](#arch-linux-build-guide)
+    - [EWS/EngrIT](#ews-engrit-build-guide) (this is UIUC-specific)
     - [Generic Setup Notes](#generic-setup-notes)
 
 # Intro
@@ -305,6 +306,81 @@ cp ../config.toml .
 
 # configure and build the project
 CXX=clang++ cmake ../ -DCMAKE_BUILD_TYPE=Release
+make
+```
+
+You can now test the system by running the following command:
+
+```bash
+ctest --output-on-failure
+```
+
+If everything passes, congratulations! MeTA seems to be working on your
+system.
+
+## EWS/EngrIT Build Guide
+If you are on a machine managed by Engineering IT at UIUC, you should
+follow this guide. These systems have software that is much too old for
+building MeTA, but EngrIT has been kind enough to package updated versions
+of research software as modules. The modules provided for GCC and CMake are
+recent enough to build MeTA, so it is actually mostly straightforward.
+
+To set up your dependencies (**you will need to do this every time you log
+back in to the system**), run the following commands:
+
+```bash
+module load gcc
+module load cmake
+```
+
+Once you have done this, double check your versions by running the
+following commands.
+
+```bash
+g++ --version
+```
+
+should output
+
+```
+g++ (GCC) 4.8.2
+Copyright (C) 2013 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+```
+
+and
+
+```bash
+cmake --version
+```
+
+should output
+
+```
+cmake version 3.1.1
+
+CMake suite maintained and supported by Kitware (kitware.com/cmake).
+```
+
+If your versions are correct, you should be ready to build. To get started,
+run the following commands:
+
+```bash
+# clone the project
+git clone https://github.com/meta-toolkit/meta.git
+cd meta/
+
+# set up submodules
+git submodule update --init --recursive
+
+# set up a build directory
+mkdir build
+cd build
+cp ../config.toml .
+
+# configure and build the project
+CXX="/software/gcc-4.8.2/bin/g++" cmake ../ -DCMAKE_BUILD_TYPE=Release
 make
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -1,15 +1,26 @@
 # MeTA: ModErn Text Analysis
 
-Please visit our [web page](http://meta-toolkit.github.io/meta/) for information
-and tutorials about MeTA!
+Please visit our [web page][meta-website] for information and tutorials
+about MeTA!
 
-## Build Status (by branch)
+### Build Status (by branch)
 - master: [![Build
   Status](https://travis-ci.org/meta-toolkit/meta.svg?branch=master)](https://travis-ci.org/meta-toolkit/meta)
 - develop: [![Build
   Status](https://travis-ci.org/meta-toolkit/meta.svg?branch=develop)](https://travis-ci.org/meta-toolkit/meta)
 
-## MeTA is a modern C++ data sciences toolkit featuring
+- [Intro](#intro)
+    - [Documentation](#documentation)
+    - [Tutorials](#tutorials)
+- [Project Setup](#project-setup)
+    - [Mac OS X](#mac-os-x-build-guide)
+    - [Ubuntu](#ubuntu-build-guide)
+    - [Arch Linux](#arch-linux-build-guide)
+    - [Generic Setup Notes](#generic-setup-notes)
+
+## Intro
+
+MeTA is a modern C++ data sciences toolkit featuring
 
  - text tokenization, including deep semantic features like parse trees
  - inverted and forward indexes with compression and various caching strategies
@@ -23,68 +34,299 @@ and tutorials about MeTA!
  - UTF8 support for analysis on various languages
  - multithreaded algorithms
 
-## Documentation
+### Documentation
 
-Doxygen documentation can be found [here]({{site.baseurl}}/doxygen/).
+Doxygen documentation can be found [here][doxygen].
 
-## Tutorials
+### Tutorials
 
-We have walkthroughs for a few different parts of MeTA on the [MeTA
-homepage](http://meta-toolkit.github.io/meta/).
+We have walkthroughs for a few different parts of MeTA on the
+[MeTA homepage][meta-website].
 
 ## Project setup
 
- - This project requires a conforming C++11 compiler. Currently, clang >=
-   3.3 is the de-facto compiler for use with this project, but it will work
-   with GCC >= 4.8 as of writing.
+### Mac OS X Build Guide
+Mac OS X 10.6 or higher is required. You may have success with 10.5, but
+this is not tested.
 
- - Additionally, you will need a conforming implementation of the C++11
-   standard library and ABI---currently libc++ and libc++abi are the best
-   options for this if you are using clang. These are installed by default
-   on OS X, but may need to be installed as separate packages on other
-   systems (e.g., Arch). See your distribution's package manager for more
-   information on installing these dependencies.
+You will need to have [homebrew][homebrew] installed, as well as the
+Command Line Tools for Xcode (homebrew requires these as well, and it will
+prompt for them during install, or you can install them with `xcode-select
+--install` on recent versions of OS X).
 
-   If you are using GCC >= 4.8, its packaged standard library and ABI is
-   sufficient.
-
- - Windows users: YMMV. It is not currently supported, but things may
-   work. You will likely need Visual Studio 2013 for the C++11 features.
-
- - This project makes use of several [git
-   submodules](http://git-scm.com/book/en/Git-Tools-Submodules). Instructions on
-   how to use them is included in the code snippet below.
-
- - Make sure you compile liblinear and libsvm (located in deps/libsvm-modules)
-   if you want to use them. It is not necessary to compile or modify any other
-    submodules.
-
- - To get started, run the following commands in the root of the project:
+Once you have homebrew installed, run the following commands to get the
+dependencies for MeTA:
 
 ```bash
-# checkout the project
+brew update
+brew install cmake
+brew install icu4c
+```
+
+To get started, run the following commands:
+
+```bash
+# clone the project
 git clone https://github.com/meta-toolkit/meta.git
 cd meta/
 
 # set up submodules
-git submodule init
-git submodule update
+git submodule update --init --recursive
 
+# set up a build directory
 mkdir build
-cd build/
+cd build
+cp ../config.toml .
 
-# to use clang
-CXX=clang++ cmake ../ -DCMAKE_BUILD_TYPE=Release
-# OR
-# to use gcc
-CXX=g++ cmake ../ -DCMAKE_BUILD_TYPE=Release
-
+# configure and build the project
+CXX=clang++ cmake ../ -DCMAKE_BUILD_TYPE=Release -DICU_ROOT=/usr/local/opt/icu4c
 make
 ```
+
+You can now test the system by running the following command:
+
+```bash
+ctest --output-on-failure
+```
+
+If everything passes, congratulations! MeTA seems to be working on your
+system.
+
+### Ubuntu Build Guide
+
+The directions here depend greatly on your installed version of Ubuntu. To
+check what version you are on, run the following command:
+
+```bash
+cat /etc/issue
+```
+
+If it reads "Ubuntu 12.04 LTS" or something of that nature, see the
+[Ubuntu 12.04 LTS Build Guide](#ubuntu-12.04-lts-build-guide). If it reads
+"Ubuntu 14.04 LTS" (or 14.10), see the
+[Ubuntu 14.04 LTS Build Guide](#ubuntu-14.04-lts-build-guide). If your
+version is less than 12.04 LTS, your operating system is not supported
+(even by your vendor) and you should upgrade to at least 12.04 LTS (or
+14.04 LTS, if possible).
+
+#### Ubuntu 12.04 LTS Build Guide
+Building on Ubuntu 12.04 LTS requires more work than its more up-to-date
+14.04 sister, but it can be done relatively easily. You will, however, need
+to install a newer C++ compiler from a ppa, and switch to it in order to
+build meta. We will also need to install a newer CMake version than is
+natively available.
+
+Start by running the following commands to get the dependencies that we
+will need for building MeTA.
+
+```bash
+# this might take a while
+sudo apt-get update
+sudo apt-get install python-software-properties
+
+# add the ppa that contains an updated g++
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+sudo apt-get update
+
+# this will probably take a while
+sudo apt-get install g++ g++-4.8 libicu-dev git make wget
+
+wget http://www.cmake.org/files/v3.1/cmake-3.1.1-Linux-x86_64.sh
+sudo sh cmake-3.1.1-Linux-x86_64.sh --prefix=/usr/local
+```
+
+During CMake installation, you should agree to the license and then say "n"
+to including the subdirectory. You should be able to run the following
+commands and see the following output:
+
+```bash
+g++-4.8 --version
+```
+
+should print
+
+```
+g++-4.8 (Ubuntu 4.8.1-2ubuntu1~12.04) 4.8.1
+Copyright (C) 2013 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+```
+
+and
+
+```bash
+/usr/local/bin/cmake --version
+```
+
+should print
+
+```
+cmake version 3.1.1
+
+CMake suite maintained and supported by Kitware (kitware.com/cmake).
+```
+
+Once the dependencies are all installed, you should be ready to build. Run
+the following commands to get started:
+
+```bash
+# clone the project
+git clone https://github.com/meta-toolkit/meta.git
+cd meta/
+
+# set up submodules
+git submodule update --init --recursive
+
+# set up a build directory
+mkdir build
+cd build
+cp ../config.toml .
+
+# configure and build the project
+CXX=g++-4.8 /usr/local/bin/cmake ../ -DCMAKE_BUILD_TYPE=Release
+make
+```
+
+You can now test the system by running the following command:
+
+```bash
+/usr/local/bin/ctest --output-on-failure
+```
+
+If everything passes, congratulations! MeTA seems to be working on your
+system.
+
+#### Ubuntu 14.04 LTS Build Guide
+Ubuntu 14.04 has a recent enough GCC for building MeTA, but we'll need to
+add a ppa for a more recent version of CMake.
+
+Start by running the following commands to install the dependencies for
+MeTA.
+
+```bash
+# this might take a while
+sudo apt-get update
+sudo apt-get install software-properties-common
+
+# add the ppa for cmake
+sudo add-apt-repository ppa:george-edison55/cmake-3.x
+sudo apt-get update
+
+# install dependencies
+sudo apt-get install cmake libicu-dev git
+```
+
+Once the dependencies are all installed, you should double check your
+versions by running the following commands.
+
+```bash
+g++ --version
+```
+
+should output
+
+```
+g++ (Ubuntu 4.8.2-19ubuntu1) 4.8.2
+Copyright (C) 2013 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+```
+
+and
+
+```bash
+cmake --version
+```
+
+should output
+
+```
+cmake version 3.1.1
+
+CMake suite maintained and supported by Kitware (kitware.com/cmake).
+```
+
+Once the dependencies are all installed, you should be ready to build. Run
+the following commands to get started:
+
+```bash
+# clone the project
+git clone https://github.com/meta-toolkit/meta.git
+cd meta/
+
+# set up submodules
+git submodule update --init --recursive
+
+# set up a build directory
+mkdir build
+cd build
+cp ../config.toml .
+
+# configure and build the project
+cmake ../ -DCMAKE_BUILD_TYPE=Release
+make
+```
+
+You can now test the system by running the following command:
+
+```bash
+ctest --output-on-failure
+```
+
+If everything passes, congratulations! MeTA seems to be working on your
+system.
+
+### Arch Linux Build Guide
+Arch Linux consistently has the most up to date packages due to its rolling
+release setup, so it's often the easiest platform to get set up on.
+
+To install the dependencies, run the following commands.
+
+```bash
+sudo pacman -Sy
+sudo pacman -S clang cmake git icu libc++ make
+```
+Once the dependencies are all installed, you should be ready to build. Run
+the following commands to get started:
+
+```bash
+# clone the project
+git clone https://github.com/meta-toolkit/meta.git
+cd meta/
+
+# set up submodules
+git submodule update --init --recursive
+
+# set up a build directory
+mkdir build
+cd build
+cp ../config.toml .
+
+# configure and build the project
+CXX=clang++ cmake ../ -DCMAKE_BUILD_TYPE=Release
+make
+```
+
+You can now test the system by running the following command:
+
+```bash
+ctest --output-on-failure
+```
+
+If everything passes, congratulations! MeTA seems to be working on your
+system.
+
+### Generic Setup Notes
 
  - There are rules for clean, tidy, and doc. **After you run the cmake command
    once, you will be able to just run `make` as usual** when you're
    developing---it'll detect when the CMakeLists.txt file has changed and
    rebuild Makefiles if it needs to.
 
- - To compile in debug mode, just replace `Release` with `Debug`.
+ - To compile in debug mode, just replace `Release` with `Debug` in the
+   appropriate `cmake` command for your OS above and rebuild using `make`
+   after.
+
+[meta-website]: https://meta-toolkit.github.io/meta/
+[doxygen]: https://meta-toolkit.github.io/meta/doxygen/namespaces.html
+[homebrew]: http://brew.sh


### PR DESCRIPTION
This PR addresses issue #52 by adding detailed setup guides for OS X, the two currently supported LTS versions of Ubuntu, and Arch Linux (because why not).

I tested everything on my local system using docker to get the different versions of Ubuntu, and booted my laptop into OS X v10.9 for the OS X instructions. They seem to be correct from those tests, and with the latest changes in develop I can easily run the unit tests on all three (everything passes).

I ended up not really saying much about selecting your compiler since the reality is that each system sort of has its own "best compiler" with the exception of Arch (for whom I doubt an install guide is even really necessary).