### PR TITLE
Gzip compressed corpora support

### DIFF
--- a/include/corpus/all.h
+++ b/include/corpus/all.h
@@ -1,3 +1,6 @@
 #include "corpus.h"
 #include "file_corpus.h"
 #include "line_corpus.h"
+#if META_HAS_ZLIB
+#include "gz_corpus.h"
+#endif

--- a/include/corpus/gz_corpus.h
+++ b/include/corpus/gz_corpus.h
@@ -1,0 +1,69 @@
+/**
+ * @file gz_corpus.h
+ * @author Chase Geigle
+ *
+ * All files in META are dual-licensed under the MIT and NCSA licenses. For more
+ * details, consult the file LICENSE.mit and LICENSE.ncsa in the root of the
+ * project.
+ */
+
+#ifndef META_GZ_CORPUS_H_
+#define META_GZ_CORPUS_H_
+
+#include "corpus/corpus.h"
+#include "io/gzstream.h"
+
+namespace meta
+{
+namespace corpus
+{
+
+/**
+ * Fills document objects with content line-by-line from gzip-compressed
+ * input files.
+ */
+class gz_corpus : public corpus
+{
+  public:
+    /**
+     * @param file The path to the compressed corpus file, where each line
+     * represents a document
+     * @param encoding The encoding for the file
+     */
+    gz_corpus(const std::string& file, std::string encoding);
+
+    /**
+     * @return whether there is another document in this corpus
+     */
+    bool has_next() const override;
+
+    /**
+     * @return the next document from this corpus
+     */
+    document next() override;
+
+    /**
+     * @return the number of documents in this corpus
+     */
+    uint64_t size() const override;
+
+  private:
+    /// The current document we are on
+    doc_id cur_id_;
+
+    /// The number of lines in the file
+    uint64_t num_lines_;
+
+    /// The stream for reading the corpus
+    io::gzifstream corpus_stream_;
+
+    /// The stream to read the class labels
+    io::gzifstream class_stream_;
+
+    /// The stream to read the document names
+    io::gzifstream name_stream_;
+};
+}
+}
+
+#endif

--- a/src/corpus/CMakeLists.txt
+++ b/src/corpus/CMakeLists.txt
@@ -2,9 +2,17 @@ project(meta-corpus)
 
 add_subdirectory(tools)
 
-add_library(meta-corpus corpus.cpp
-                        document.cpp
-                        file_corpus.cpp
-                        line_corpus.cpp)
+if (ZLIB_FOUND)
+    add_library(meta-corpus corpus.cpp
+                            document.cpp
+                            file_corpus.cpp
+                            line_corpus.cpp
+                            gz_corpus.cpp)
+else()
+    add_library(meta-corpus corpus.cpp
+                            document.cpp
+                            file_corpus.cpp
+                            line_corpus.cpp)
+endif()
 # some corpus classes use io::parser
 target_link_libraries(meta-corpus meta-io)

--- a/src/corpus/corpus.cpp
+++ b/src/corpus/corpus.cpp
@@ -52,21 +52,29 @@ std::unique_ptr<corpus> corpus::load(const std::string& config_file)
         if (!file_list)
             throw corpus_exception{"list missing from configuration file"};
 
-        std::string file =
-            *prefix + "/" + *dataset + "/" + *file_list + "-full-corpus.txt";
-        return make_unique<file_corpus>(*prefix + "/"
-                                        + *dataset + "/", file, encoding);
+        std::string file = *prefix + "/" + *dataset + "/" + *file_list
+                           + "-full-corpus.txt";
+        return make_unique<file_corpus>(*prefix + "/" + *dataset + "/", file,
+                                        encoding);
     }
     else if (*type == "line-corpus")
     {
-        std::string filename =
-            *prefix + "/" + *dataset + "/" + *dataset + ".dat";
+        std::string filename = *prefix + "/" + *dataset + "/" + *dataset
+                               + ".dat";
         auto lines = config.get_as<int64_t>("num-lines");
         if (!lines)
             return make_unique<line_corpus>(filename, encoding);
         return make_unique<line_corpus>(filename, encoding,
                                         static_cast<uint64_t>(*lines));
     }
+#if META_HAS_ZLIB
+    else if (*type == "gz-corpus")
+    {
+        std::string filename = *prefix + "/" + *dataset + "/" + *dataset
+                               + ".dat";
+        return make_unique<gz_corpus>(filename, encoding);
+    }
+#endif
     else
         throw corpus_exception{"corpus type was not able to be determined"};
 }

--- a/src/corpus/gz_corpus.cpp
+++ b/src/corpus/gz_corpus.cpp
@@ -1,0 +1,66 @@
+/**
+ * @file gz_corpus.cpp
+ * @author Chase Geigle
+ */
+
+#include "corpus/gz_corpus.h"
+#include "util/filesystem.h"
+
+namespace meta
+{
+namespace corpus
+{
+
+gz_corpus::gz_corpus(const std::string& file, std::string encoding)
+    : corpus{std::move(encoding)},
+      cur_id_{0},
+      corpus_stream_{file + ".gz"},
+      class_stream_{file + ".labels.gz"},
+      name_stream_{file + ".names.gz"}
+{
+    if (!filesystem::file_exists(file + ".numdocs"))
+        throw corpus::corpus_exception{
+            file + ".numdocs file does not exist (required for gz_corpus)"};
+
+    try
+    {
+        num_lines_ = std::stoul(filesystem::file_text(file + ".numdocs"));
+    }
+    catch (const std::exception& ex)
+    {
+        throw corpus::corpus_exception{"Malformed numdocs file " + file
+                                       + ".numdocs: " + ex.what()};
+    }
+}
+
+bool gz_corpus::has_next() const
+{
+    return cur_id_ != num_lines_;
+}
+
+document gz_corpus::next()
+{
+    class_label label{"[none]"};
+    std::string name{"[none]"};
+
+    if (class_stream_)
+        std::getline(class_stream_, static_cast<std::string&>(label));
+
+    if (name_stream_)
+        std::getline(name_stream_, name);
+
+    std::string line;
+    std::getline(corpus_stream_, line);
+
+    document doc{name, cur_id_++, label};
+    doc.content(line, encoding());
+
+    return doc;
+}
+
+uint64_t gz_corpus::size() const
+{
+    return num_lines_;
+}
+}
+}

--- a/src/test/inverted_index_test.cpp
+++ b/src/test/inverted_index_test.cpp
@@ -149,6 +149,28 @@ int inverted_index_tests()
         check_term_id(*idx); // twice to check splay_caching
     });
 
+#if META_HAS_ZLIB
+    create_config("gz");
+    system("rm -rf ceeaus-inv");
+
+    num_failed += testing::run_test("inverted-index-build-gz-corpus", [&]()
+                                    {
+        auto idx
+            = index::make_index<index::inverted_index, caching::splay_cache>(
+                "test-config.toml", 10000);
+        check_ceeaus_expected(*idx);
+    });
+
+    num_failed += testing::run_test("inverted-index-read-gz-corpus", [&]()
+                                    {
+        auto idx
+            = index::make_index<index::inverted_index, caching::splay_cache>(
+                "test-config.toml", 10000);
+        check_ceeaus_expected(*idx);
+        check_term_id(*idx);
+    });
+#endif
+
     // test different caches
 
     num_failed += testing::run_test("inverted-index-dblru-cache", [&]()

--- a/src/test/inverted_index_test.cpp
+++ b/src/test/inverted_index_test.cpp
@@ -17,15 +17,15 @@ void create_config(const std::string& corpus_type)
     std::ofstream config_file{config_filename};
 
     auto stop_words = orig_config.get_as<std::string>("stop-words");
-    if(!stop_words)
+    if (!stop_words)
         throw std::runtime_error{"\"stop-words\" not in config"};
 
     auto libsvm_modules = orig_config.get_as<std::string>("libsvm-modules");
-    if(!libsvm_modules)
+    if (!libsvm_modules)
         throw std::runtime_error{"\"libsvm-modules\" not in config"};
 
     auto query_judgements = orig_config.get_as<std::string>("query-judgements");
-    if(!query_judgements)
+    if (!query_judgements)
         throw std::runtime_error{"\"query-judgements\" not in config"};
 
     auto punctuation = orig_config.get_as<std::string>("punctuation");
@@ -40,17 +40,14 @@ void create_config(const std::string& corpus_type)
     if (!end_exceptions)
         throw std::runtime_error{"\"end-exceptions\" not in config"};
 
-    config_file << "stop-words = \"" << *stop_words
-                << "\"\n"
+    config_file << "stop-words = \"" << *stop_words << "\"\n"
                 << "punctuation = \"" << *punctuation << "\"\n"
                 << "start-exceptions = \"" << *start_exeptions << "\"\n"
                 << "end-exceptions = \"" << *end_exceptions << "\"\n"
                 << "prefix = \"" << *orig_config.get_as<std::string>("prefix")
                 << "\"\n"
-                << "query-judgements = \"" << *query_judgements
-                << "\"\n"
-                << "libsvm-modules = \"" << *libsvm_modules
-                << "\"\n"
+                << "query-judgements = \"" << *query_judgements << "\"\n"
+                << "libsvm-modules = \"" << *libsvm_modules << "\"\n"
                 << "corpus-type = \"" << corpus_type << "-corpus\"\n"
                 << "list= \"ceeaus\"\n"
                 << "dataset = \"ceeaus\"\n"
@@ -111,21 +108,23 @@ int inverted_index_tests()
 
     int num_failed = 0;
     num_failed += testing::run_test("inverted-index-build-file-corpus", [&]()
-    {
+                                    {
         system("rm -rf ceeaus-inv");
-        auto idx =
-            index::make_index<index::inverted_index, caching::splay_cache>(
+        auto idx
+            = index::make_index<index::inverted_index, caching::splay_cache>(
                 "test-config.toml", uint32_t{10000});
         check_ceeaus_expected(*idx);
     });
 
     num_failed += testing::run_test("inverted-index-read-file-corpus", [&]()
-    {
-        auto idx =
-            index::make_index<index::inverted_index, caching::splay_cache>(
+                                    {
+        {
+            auto idx = index::make_index<index::inverted_index,
+                                         caching::splay_cache>(
                 "test-config.toml", uint32_t{10000});
-        check_ceeaus_expected(*idx);
-        check_term_id(*idx);
+            check_ceeaus_expected(*idx);
+            check_term_id(*idx);
+        }
         system("rm -rf ceeaus-inv test-config.toml");
     });
 
@@ -133,17 +132,17 @@ int inverted_index_tests()
     system("rm -rf ceeaus-inv");
 
     num_failed += testing::run_test("inverted-index-build-line-corpus", [&]()
-    {
-        auto idx =
-            index::make_index<index::inverted_index, caching::splay_cache>(
+                                    {
+        auto idx
+            = index::make_index<index::inverted_index, caching::splay_cache>(
                 "test-config.toml", uint32_t{10000});
         check_ceeaus_expected(*idx);
     });
 
     num_failed += testing::run_test("inverted-index-read-line-corpus", [&]()
-    {
-        auto idx =
-            index::make_index<index::inverted_index, caching::splay_cache>(
+                                    {
+        auto idx
+            = index::make_index<index::inverted_index, caching::splay_cache>(
                 "test-config.toml", uint32_t{10000});
         check_ceeaus_expected(*idx);
         check_term_id(*idx);
@@ -153,7 +152,7 @@ int inverted_index_tests()
     // test different caches
 
     num_failed += testing::run_test("inverted-index-dblru-cache", [&]()
-    {
+                                    {
         auto idx = index::make_index<index::inverted_index,
                                      caching::default_dblru_cache>(
             "test-config.toml", uint64_t{1000});
@@ -162,16 +161,16 @@ int inverted_index_tests()
     });
 
     num_failed += testing::run_test("inverted-index-no-evict-cache", [&]()
-    {
-        auto idx =
-            index::make_index<index::inverted_index, caching::no_evict_cache>(
+                                    {
+        auto idx
+            = index::make_index<index::inverted_index, caching::no_evict_cache>(
                 "test-config.toml");
         check_term_id(*idx);
         check_term_id(*idx);
     });
 
     num_failed += testing::run_test("inverted-index-shard-cache", [&]()
-    {
+                                    {
         auto idx = index::make_index<index::inverted_index,
                                      caching::splay_shard_cache>(
             "test-config.toml", uint8_t{8});

--- a/src/test/ranker_test.cpp
+++ b/src/test/ranker_test.cpp
@@ -77,6 +77,8 @@ int ranker_tests()
         test_rank(r, *idx, encoding);
     });
 
+    idx = nullptr;
+
     system("rm -rf ceeaus-inv test-config.toml");
     return num_failed;
 }

--- a/src/test/tools/CMakeLists.txt
+++ b/src/test/tools/CMakeLists.txt
@@ -2,7 +2,7 @@ ExternalProject_Add(ceeaus
   SOURCE_DIR ${meta_BINARY_DIR}/../../data/ceeaus
   DOWNLOAD_DIR ${meta_BINARY_DIR}/downloads
   URL http://web.engr.illinois.edu/~massung1/files/ceeaus.tar.gz
-  URL_HASH "SHA256=046c8135b51eec8ad045742618e838d37a5a51a05ce0c82f5d39bde09e1f7e90"
+  URL_HASH "SHA256=dbcdecc4098bd02dd31c35930fad9ae81a85dc07ac79f734a127fe915a52ca25"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND "")

--- a/src/test/tools/CMakeLists.txt
+++ b/src/test/tools/CMakeLists.txt
@@ -2,7 +2,7 @@ ExternalProject_Add(ceeaus
   SOURCE_DIR ${meta_BINARY_DIR}/../../data/ceeaus
   DOWNLOAD_DIR ${meta_BINARY_DIR}/downloads
   URL http://web.engr.illinois.edu/~massung1/files/ceeaus.tar.gz
-  URL_HASH "SHA256=81f45b8f4081d11e01575cf344d6343e160a67460e349a370049daa2aaeede18"
+  URL_HASH "SHA256=046c8135b51eec8ad045742618e838d37a5a51a05ce0c82f5d39bde09e1f7e90"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND "")


### PR DESCRIPTION
This adds `gz_corpus`, which is like a compressed `line_corpus`. It's a separate class because supporting it within `line_corpus` itself gets too ugly (see issue #66).

This is a pretty small change, but I'm making it a PR because it needs to be merged only when the ceeaus.tar.gz data file hosted on @smassung's web space is updated to include:

- `ceeaus.dat.gz`, a gzipped version of `ceeaus.dat`
- `ceeaus.dat.labels.gz`, a gzipped version of the labels
- `ceeaus.dat.names.gz`, a gzipped version of the names
- `ceeaus.dat.numdocs`, a file containing *just* the number of documents in ceeaus

Once those are in that file, the unit tests should pass (since they do locally). Once they're passing, we should merge (and probably consider using this format for anywhere we're currently using `line_corpus` data). This doesn't deprecate `line_corpus` entirely, since (at least right now) we don't assume that the user *must* have zlib available (although we certainly *could*).