### PR TITLE
Updated ir_eval.cpp

### DIFF
--- a/src/index/eval/ir_eval.cpp
+++ b/src/index/eval/ir_eval.cpp
@@ -181,8 +181,8 @@ double ir_eval::avg_p(const std::vector<std::pair<doc_id, double>>& results,
             break;
     }
 
-    scores_.push_back(avgp / (i - 1.0));
-    return avgp / (i - 1.0);
+    scores_.push_back(avgp / ht->second.size());
+    return avgp / ht->second.size();
 }
 
 double ir_eval::map() const


### PR DESCRIPTION
Fixed the denominator of avg_p and made it equal to the number of relevant documents as calculated from the relevance judgements file.