### PR TITLE
language_model optimizations

### DIFF
--- a/include/lm/language_model.h
+++ b/include/lm/language_model.h
@@ -17,6 +17,7 @@
 #include "cpptoml.h"
 #include "lm/sentence.h"
 #include "lm/static_probe_map.h"
+#include "lm/token_list.h"
 
 namespace meta
 {
@@ -77,7 +78,7 @@ class language_model
      * @param tokens A sequence of n tokens (one sentence)
      * @return the log probability of the likelihood of this sentence
      */
-    float log_prob(sentence tokens) const;
+    float log_prob(const sentence& tokens) const;
 
     /**
      * @param prev Seen tokens to base the next token off of
@@ -100,10 +101,15 @@ class language_model
      * @param tokens
      * @return the log probability of one ngram
      */
-    float prob_calc(sentence tokens) const;
+    float prob_calc(token_list tokens) const;
 
     /**
-     * Loads unigram vocabulary from text file to allow top_k to work.
+     * Internal log_prob that takes a token_list
+     */
+    float log_prob(const token_list& tokens) const;
+
+    /**
+     * Loads unigram vocabulary from text file
      */
     void load_vocab();
 
@@ -111,9 +117,11 @@ class language_model
 
     std::vector<static_probe_map> lm_;
 
-    std::vector<std::string> vocabulary_;
+    std::unordered_map<std::string, term_id> vocabulary_;
 
     std::string prefix_;
+
+    float unk_prob_;
 };
 
 class language_model_exception : public std::runtime_error

--- a/include/lm/static_probe_map.h
+++ b/include/lm/static_probe_map.h
@@ -55,6 +55,22 @@ class static_probe_map
     util::optional<lm_node> find(const token_list& key) const;
 
     /**
+     * Finds a key represented by a pair of iterators.
+     *
+     * @param begin The beginning of the list of token ids
+     * @param end The ending of the list of token ids
+     * @return an optional language model node containing the probability
+     * and backoff value for the key
+     */
+    template <class ForwardIterator>
+    util::optional<lm_node> find(ForwardIterator begin,
+                                 ForwardIterator end) const
+    {
+        auto hashed = hash(begin, end);
+        return find_hash(hashed);
+    }
+
+    /**
      * @param key The string key to insert (though only a uint64_t hash is
      * stored; if the hash already exists, an exception is thrown)
      * @param prob The probability of the key in this LM
@@ -67,6 +83,24 @@ class static_probe_map
      * Helper function to create hasher and hash token list
      */
     uint64_t hash(const token_list& tokens) const;
+
+    /**
+     * Helper function to create hasher and hash token list parameterized
+     * as a pair of iterators
+     */
+    template <class ForwardIterator>
+    uint64_t hash(ForwardIterator begin, ForwardIterator end) const
+    {
+        util::murmur_hash<> hasher{seed_};
+        auto dist = std::distance(begin, end);
+        for (; begin != end; ++begin)
+            hash_append(hasher, *begin);
+        hash_append(hasher, dist);
+        return static_cast<std::size_t>(hasher);
+    }
+
+    /// Helper function to find a node given the hash value
+    util::optional<lm_node> find_hash(uint64_t hashed) const;
 
     /// A seed for the string hash function
     static constexpr uint64_t seed_ = 0x2bedf99b3aa222d9;

--- a/include/lm/static_probe_map.h
+++ b/include/lm/static_probe_map.h
@@ -12,6 +12,7 @@
 
 #include <utility>
 #include "lm/lm_node.h"
+#include "lm/token_list.h"
 #include "util/disk_vector.h"
 #include "util/optional.h"
 
@@ -51,7 +52,7 @@ class static_probe_map
      * @return an optional language model node containing the probability and
      * backoff value for the key
      */
-    util::optional<lm_node> find(const std::string& key) const;
+    util::optional<lm_node> find(const token_list& key) const;
 
     /**
      * @param key The string key to insert (though only a uint64_t hash is
@@ -59,13 +60,13 @@ class static_probe_map
      * @param prob The probability of the key in this LM
      * @param backoff The backoff probability for this LM
      */
-    void insert(const std::string& key, float prob, float backoff);
+    void insert(const token_list& key, float prob, float backoff);
 
   private:
     /**
-     * Helper function to create hasher and hash str
+     * Helper function to create hasher and hash token list
      */
-    uint64_t hash(const std::string& str) const;
+    uint64_t hash(const token_list& tokens) const;
 
     /// A seed for the string hash function
     static constexpr uint64_t seed_ = 0x2bedf99b3aa222d9;

--- a/include/lm/token_list.h
+++ b/include/lm/token_list.h
@@ -107,9 +107,7 @@ inline bool operator!=(const token_list& lhs, const token_list& rhs)
 template <class HashAlgorithm>
 void hash_append(HashAlgorithm& h, const token_list& list)
 {
-    using util::hash_append;
-    for (const auto& val : list.tokens())
-        hash_append(h, val);
+    h(list.tokens().data(), sizeof(term_id) * list.size());
     hash_append(h, list.size());
 }
 }

--- a/include/lm/token_list.h
+++ b/include/lm/token_list.h
@@ -88,7 +88,7 @@ class token_list
     /**
      * @return the underlying container of term_id tokens
      */
-    const std::vector<term_id> tokens() const;
+    const std::vector<term_id>& tokens() const;
 
   private:
     std::vector<term_id> tokens_;

--- a/include/lm/token_list.h
+++ b/include/lm/token_list.h
@@ -1,0 +1,118 @@
+/**
+ * @file token_list.h
+ * @author Sean Massung
+ *
+ * All files in META are dual-licensed under the MIT and NCSA licenses. For more
+ * details, consult the file LICENSE.mit and LICENSE.ncsa in the root of the
+ * project.
+ */
+
+#ifndef META_LM_TOKEN_LIST_H_
+#define META_LM_TOKEN_LIST_H_
+
+#include <unordered_map>
+#include <sstream>
+#include "meta.h"
+#include "lm/sentence.h"
+#include "util/hash.h"
+
+namespace meta
+{
+namespace lm
+{
+class token_list
+{
+  public:
+    /**
+     * Constructor that takes a std::string, splits it, and assigns ids to each
+     * token based on vocab
+     * @param ngram
+     * @param vocab
+     */
+    token_list(const std::string& ngram,
+               const std::unordered_map<std::string, term_id>& vocab);
+
+    /**
+     * Constructor that takes an lm::sentence and assigns ids to each one based
+     * on vocab
+     * @param ngram
+     * @param vocab
+     */
+    token_list(const lm::sentence& ngram,
+               const std::unordered_map<std::string, term_id>& vocab);
+
+    /**
+     * Constructor that creates a token list with a single element
+     * @param val
+     */
+    token_list(term_id val);
+
+    /**
+     * Default constructor.
+     */
+    token_list() = default;
+
+    /**
+     * @param idx
+     * @return the token id of the element at location idx
+     */
+    const term_id& operator[](uint64_t idx) const;
+
+    /**
+     * @param idx
+     * @return the token id of the element at location idx
+     */
+    term_id& operator[](uint64_t idx);
+
+    /**
+     * @return the number of tokens in this list
+     */
+    uint64_t size() const;
+
+    /**
+     * Add elem to the end of the list
+     * @param elem
+     */
+    void push_back(term_id elem);
+
+    /**
+     * Remove the first token
+     */
+    void pop_front();
+
+    /**
+     * Remove the last token
+     */
+    void pop_back();
+
+    /**
+     * @return the underlying container of term_id tokens
+     */
+    const std::vector<term_id> tokens() const;
+
+  private:
+    std::vector<term_id> tokens_;
+};
+
+inline bool operator==(const token_list& lhs, const token_list& rhs)
+{
+    return lhs.tokens() == rhs.tokens();
+}
+
+inline bool operator!=(const token_list& lhs, const token_list& rhs)
+{
+    return !(lhs == rhs);
+}
+
+template <class HashAlgorithm>
+void hash_append(HashAlgorithm& h, const token_list& list)
+{
+    using util::hash_append;
+    for (const auto& val : list.tokens())
+        hash_append(h, val);
+    hash_append(h, list.size());
+}
+}
+}
+
+#endif

--- a/src/lm/CMakeLists.txt
+++ b/src/lm/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory(tools)
 add_subdirectory(analyzers)
 
 add_library(meta-language-model language_model.cpp
+                                token_list.cpp
                                 diff.cpp
                                 static_probe_map.cpp
                                 sentence.cpp)

--- a/src/lm/static_probe_map.cpp
+++ b/src/lm/static_probe_map.cpp
@@ -59,7 +59,7 @@ util::optional<lm_node> static_probe_map::find(const token_list& key) const
 uint64_t static_probe_map::hash(const token_list& tokens) const
 {
     util::murmur_hash<> hasher{seed_};
-    hasher(tokens.tokens().data(), tokens.size() * sizeof(term_id));
+    hash_append(hasher, tokens);
     return static_cast<std::size_t>(hasher);
 }
 }

--- a/src/lm/static_probe_map.cpp
+++ b/src/lm/static_probe_map.cpp
@@ -17,7 +17,7 @@ static_probe_map::static_probe_map(const std::string& filename,
 {
 }
 
-void static_probe_map::insert(const std::string& key, float prob, float backoff)
+void static_probe_map::insert(const token_list& key, float prob, float backoff)
 {
     auto hashed = hash(key);
     auto idx = (hashed % (table_.size() / 2)) * 2;
@@ -39,7 +39,7 @@ void static_probe_map::insert(const std::string& key, float prob, float backoff)
     }
 }
 
-util::optional<lm_node> static_probe_map::find(const std::string& key) const
+util::optional<lm_node> static_probe_map::find(const token_list& key) const
 {
     auto hashed = hash(key);
     auto idx = (hashed % (table_.size() / 2)) * 2;
@@ -56,10 +56,10 @@ util::optional<lm_node> static_probe_map::find(const std::string& key) const
     }
 }
 
-uint64_t static_probe_map::hash(const std::string& str) const
+uint64_t static_probe_map::hash(const token_list& tokens) const
 {
     util::murmur_hash<> hasher{seed_};
-    hasher(str.data(), str.length());
+    hasher(tokens.tokens().data(), tokens.size() * sizeof(term_id));
     return static_cast<std::size_t>(hasher);
 }
 }

--- a/src/lm/static_probe_map.cpp
+++ b/src/lm/static_probe_map.cpp
@@ -42,6 +42,11 @@ void static_probe_map::insert(const token_list& key, float prob, float backoff)
 util::optional<lm_node> static_probe_map::find(const token_list& key) const
 {
     auto hashed = hash(key);
+    return find_hash(hashed);
+}
+
+util::optional<lm_node> static_probe_map::find_hash(uint64_t hashed) const
+{
     auto idx = (hashed % (table_.size() / 2)) * 2;
 
     while (true)
@@ -58,9 +63,7 @@ util::optional<lm_node> static_probe_map::find(const token_list& key) const
 
 uint64_t static_probe_map::hash(const token_list& tokens) const
 {
-    util::murmur_hash<> hasher{seed_};
-    hash_append(hasher, tokens);
-    return static_cast<std::size_t>(hasher);
+    return hash(tokens.tokens().begin(), tokens.tokens().end());
 }
 }
 }

--- a/src/lm/token_list.cpp
+++ b/src/lm/token_list.cpp
@@ -72,7 +72,7 @@ void token_list::pop_back()
     tokens_.pop_back();
 }
 
-const std::vector<term_id> token_list::tokens() const
+const std::vector<term_id>& token_list::tokens() const
 {
     return tokens_;
 }

--- a/src/lm/token_list.cpp
+++ b/src/lm/token_list.cpp
@@ -27,6 +27,7 @@ token_list::token_list(const std::string& ngram,
 token_list::token_list(const lm::sentence& ngram,
            const std::unordered_map<std::string, term_id>& vocab)
 {
+    tokens_.reserve(ngram.size());
     for (const auto& token : ngram)
     {
         auto it = vocab.find(token);

--- a/src/lm/token_list.cpp
+++ b/src/lm/token_list.cpp
@@ -1,0 +1,80 @@
+/**
+ * @file token_list.cpp
+ * @author Sean Massung
+ */
+
+#include "lm/token_list.h"
+
+namespace meta
+{
+namespace lm
+{
+token_list::token_list(const std::string& ngram,
+           const std::unordered_map<std::string, term_id>& vocab)
+{
+    std::string token;
+    std::istringstream iss{ngram};
+    while (iss >> token)
+    {
+        auto it = vocab.find(token);
+        if (it != vocab.end())
+            tokens_.push_back(it->second);
+        else
+            tokens_.push_back(vocab.at("<unk>"));
+    }
+}
+
+token_list::token_list(const lm::sentence& ngram,
+           const std::unordered_map<std::string, term_id>& vocab)
+{
+    for (const auto& token : ngram)
+    {
+        auto it = vocab.find(token);
+        if (it != vocab.end())
+            tokens_.push_back(it->second);
+        else
+            tokens_.push_back(vocab.at("<unk>"));
+    }
+}
+
+token_list::token_list(term_id val)
+{
+    tokens_.push_back(val);
+}
+
+const term_id& token_list::operator[](uint64_t idx) const
+{
+    return tokens_[idx];
+}
+
+term_id& token_list::operator[](uint64_t idx)
+{
+    return tokens_[idx];
+}
+
+uint64_t token_list::size() const
+{
+    return tokens_.size();
+}
+
+void token_list::push_back(term_id elem)
+{
+    tokens_.push_back(elem);
+}
+
+void token_list::pop_front()
+{
+    tokens_.erase(tokens_.begin());
+}
+
+void token_list::pop_back()
+{
+    tokens_.pop_back();
+}
+
+const std::vector<term_id> token_list::tokens() const
+{
+    return tokens_;
+}
+}
+}


### PR DESCRIPTION
This improves the `language_model` operation running times. As a test on my own computer, these changes made `diff-test` run in 1m12s compared to 1m55s originally on the CoNLL data.