### PR TITLE
Add tokenize function to forward index

### DIFF
--- a/include/meta/index/forward_index.h
+++ b/include/meta/index/forward_index.h
@@ -15,6 +15,7 @@
 #include "meta/index/disk_index.h"
 #include "meta/index/make_index.h"
 #include "meta/index/postings_stream.h"
+#include "meta/learn/instance.h"
 #include "meta/util/disk_vector.h"
 #include "meta/util/optional.h"
 #include "meta/meta.h"
@@ -141,6 +142,12 @@ class forward_index : public disk_index
      * @return the number of unique terms in the index
      */
     virtual uint64_t unique_terms() const override;
+
+    /**
+     * @param doc The document to tokenize
+     * @return the analyzed version of the document as a feature vector
+     */
+    learn::feature_vector tokenize(const corpus::document& doc);
 
   private:
     /**

--- a/include/meta/learn/dataset.h
+++ b/include/meta/learn/dataset.h
@@ -10,66 +10,19 @@
 #define META_LEARN_DATASET_H_
 
 #include <memory>
+
 #include "meta/corpus/metadata.h"
 #include "meta/index/forward_index.h"
 #include "meta/index/inverted_index.h"
 #include "meta/index/postings_data.h"
+#include "meta/learn/instance.h"
 #include "meta/util/progress.h"
 #include "meta/util/range.h"
-#include "meta/util/sparse_vector.h"
-#include "meta/util/identifiers.h"
 
 namespace meta
 {
 namespace learn
 {
-
-using feature_id = term_id;
-using feature_vector = util::sparse_vector<feature_id, double>;
-
-MAKE_NUMERIC_IDENTIFIER_UDL(instance_id, uint64_t, _inst_id)
-
-inline void print_liblinear(std::ostream& os, const feature_vector& weights)
-{
-    for (const auto& count : weights)
-        os << ' ' << (count.first + 1) << ':' << count.second;
-}
-
-/**
- * Represents an instance in the dataset, consisting of its id and
- * feature_vector.
- */
-struct instance
-{
-    template <class ForwardIterator>
-    instance(instance_id inst_id, ForwardIterator begin, ForwardIterator end)
-        : id{inst_id}, weights{begin, end}
-    {
-        // nothing
-    }
-
-    instance(instance_id inst_id, feature_vector wv)
-        : id{inst_id}, weights{std::move(wv)}
-    {
-        // nothing
-    }
-
-    instance(instance_id inst_id) : id{inst_id}, weights{}
-    {
-        // nothing
-    }
-
-    void print_liblinear(std::ostream& os) const
-    {
-        learn::print_liblinear(os, weights);
-    }
-
-    /// the id within the dataset that contains this instance
-    instance_id id;
-    /// the weights of the features in this instance
-    const feature_vector weights;
-};
-
 /**
  * Represents an in-memory view of a set of documents for running learning
  * algorithms over.

--- a/include/meta/learn/instance.h
+++ b/include/meta/learn/instance.h
@@ -1,0 +1,66 @@
+/**
+ * @file instance.h
+ * @author Chase Geigle
+ *
+ * All files in META are released under the MIT license. For more details,
+ * consult the file LICENSE in the root of the project.
+ */
+
+#ifndef META_LEARN_INSTANCE_H_
+#define META_LEARN_INSTANCE_H_
+
+#include "meta/util/sparse_vector.h"
+#include "meta/util/identifiers.h"
+
+namespace meta
+{
+namespace learn
+{
+using feature_id = term_id;
+using feature_vector = util::sparse_vector<feature_id, double>;
+
+MAKE_NUMERIC_IDENTIFIER_UDL(instance_id, uint64_t, _inst_id)
+
+inline void print_liblinear(std::ostream& os, const feature_vector& weights)
+{
+    for (const auto& count : weights)
+        os << ' ' << (count.first + 1) << ':' << count.second;
+}
+
+/**
+ * Represents an instance in the dataset, consisting of its id and
+ * feature_vector.
+ */
+struct instance
+{
+    template <class ForwardIterator>
+    instance(instance_id inst_id, ForwardIterator begin, ForwardIterator end)
+        : id{inst_id}, weights{begin, end}
+    {
+        // nothing
+    }
+
+    instance(instance_id inst_id, feature_vector wv)
+        : id{inst_id}, weights{std::move(wv)}
+    {
+        // nothing
+    }
+
+    instance(instance_id inst_id) : id{inst_id}, weights{}
+    {
+        // nothing
+    }
+
+    void print_liblinear(std::ostream& os) const
+    {
+        learn::print_liblinear(os, weights);
+    }
+
+    /// the id within the dataset that contains this instance
+    instance_id id;
+    /// the weights of the features in this instance
+    const feature_vector weights;
+};
+}
+}
+#endif

--- a/tests/forward_index_test.cpp
+++ b/tests/forward_index_test.cpp
@@ -191,11 +191,18 @@ go_bandit([]() {
             corpus::document doc;
             doc.content(text);
             auto fvector = idx->tokenize(doc);
-            AssertThat(fvector.at(term_id{0}), Equals(1));
-            AssertThat(fvector.at(term_id{1}), Equals(1));
-            AssertThat(fvector.at(term_id{276}), Equals(1));
-            AssertThat(fvector.at(term_id{3343}), Equals(2));
-            AssertThat(fvector.at(term_id{3731}), Equals(1));
+
+            auto begin_sent = idx->get_term_id("<s>");
+            auto end_sent = idx->get_term_id("</s>");
+            auto bad = idx->get_term_id("bad");
+            auto smoke = idx->get_term_id("smoke");
+            auto think = idx->get_term_id("think");
+
+            AssertThat(fvector.at(begin_sent), Equals(1));
+            AssertThat(fvector.at(end_sent), Equals(1));
+            AssertThat(fvector.at(bad), Equals(1));
+            AssertThat(fvector.at(smoke), Equals(2));
+            AssertThat(fvector.at(think), Equals(1));
             AssertThat(fvector.at(term_id{2}), Equals(0));
         });
     });

--- a/tests/forward_index_test.cpp
+++ b/tests/forward_index_test.cpp
@@ -203,7 +203,9 @@ go_bandit([]() {
             AssertThat(fvector.at(bad), Equals(1));
             AssertThat(fvector.at(smoke), Equals(2));
             AssertThat(fvector.at(think), Equals(1));
-            AssertThat(fvector.at(term_id{2}), Equals(0));
+
+            auto oov = idx->get_term_id("somelongrandomword");
+            AssertThat(fvector.at(oov), Equals(0));
         });
     });
 

--- a/tests/forward_index_test.cpp
+++ b/tests/forward_index_test.cpp
@@ -183,6 +183,21 @@ go_bandit([]() {
             line_cfg->insert("uninvert", true);
             ceeaus_forward_test(*line_cfg);
         });
+
+        it("should analyze a new document with the current analyzer", [&]() {
+            auto cfg = tests::create_config("line");
+            auto idx = index::make_index<index::forward_index>(*cfg);
+            std::string text{"I think smoking smoking bad."};
+            corpus::document doc;
+            doc.content(text);
+            auto fvector = idx->tokenize(doc);
+            AssertThat(fvector.at(term_id{0}), Equals(1));
+            AssertThat(fvector.at(term_id{1}), Equals(1));
+            AssertThat(fvector.at(term_id{276}), Equals(1));
+            AssertThat(fvector.at(term_id{3343}), Equals(2));
+            AssertThat(fvector.at(term_id{3731}), Equals(1));
+            AssertThat(fvector.at(term_id{2}), Equals(0));
+        });
     });
 
     describe("[forward-index] from svm config", []() {
@@ -194,6 +209,15 @@ go_bandit([]() {
         });
 
         it("should load the index", [&]() { bcancer_forward_test(*svm_cfg); });
+
+        it("should not tokenize new docs", [&](){
+            auto cfg = create_libsvm_config();
+            auto idx = index::make_index<index::forward_index>(*cfg);
+            std::string text{"This should fail"};
+            corpus::document doc;
+            doc.content(text);
+            AssertThrows(index::forward_index_exception, idx->tokenize(doc));
+        });
     });
 
     describe("[forward-index] with zlib", []() {


### PR DESCRIPTION
PR for sanity check. Also breaks `learn::instance` into its own class.