### PR TITLE
Add a minimal perfect hashing language model implementation

### DIFF
--- a/include/meta/embeddings/coocur_record.h
+++ b/include/meta/embeddings/coocur_record.h
@@ -31,24 +31,6 @@ struct coocur_record
     {
         weight += other.weight;
     }
-
-    template <class OutputStream>
-    uint64_t write(OutputStream& os) const
-    {
-        auto bytes = io::packed::write(os, target);
-        bytes += io::packed::write(os, context);
-        bytes += io::packed::write(os, weight);
-        return bytes;
-    }
-
-    template <class InputStream>
-    uint64_t read(InputStream& is)
-    {
-        auto bytes = io::packed::read(is, target);
-        bytes += io::packed::read(is, context);
-        bytes += io::packed::read(is, weight);
-        return bytes;
-    }
 };
 
 bool operator==(const coocur_record& a, const coocur_record& b)
@@ -64,6 +46,22 @@ bool operator!=(const coocur_record& a, const coocur_record& b)
 bool operator<(const coocur_record& a, const coocur_record& b)
 {
     return std::tie(a.target, a.context) < std::tie(b.target, b.context);
+}
+
+template <class OutputStream>
+uint64_t packed_write(OutputStream& os, const coocur_record& record)
+{
+    using io::packed::write;
+    return write(os, record.target) + write(os, record.context)
+           + write(os, record.weight);
+}
+
+template <class InputStream>
+uint64_t packed_read(InputStream& is, coocur_record& record)
+{
+    using io::packed::read;
+    return read(is, record.target) + read(is, record.context)
+           + read(is, record.weight);
 }
 }
 }

--- a/include/meta/hashing/hash.h
+++ b/include/meta/hashing/hash.h
@@ -181,6 +181,14 @@ template <class HashAlgorithm, class T1, class T2, class... Ts>
 void hash_append(HashAlgorithm& h, const T1& first, const T2& second,
                  const Ts&... ts);
 
+template <class HashAlgorithm, class T, class Alloc>
+typename std::enable_if<is_contiguously_hashable<T>::value>::type
+hash_append(HashAlgorithm& h, const std::vector<T, Alloc>& v);
+
+template <class HashAlgorithm, class T, class Alloc>
+typename std::enable_if<!is_contiguously_hashable<T>::value>::type
+hash_append(HashAlgorithm& h, const std::vector<T, Alloc>& v);
+
 // begin implementations for hash_append
 
 template <class HashAlgorithm, class T, std::size_t N>
@@ -256,6 +264,23 @@ hash_append(HashAlgorithm& h, const std::basic_string<Char, Traits, Alloc>& s)
     for (const auto& c : s)
         hash_append(h, c);
     hash_append(h, s.size());
+}
+
+template <class HashAlgorithm, class T, class Alloc>
+typename std::enable_if<is_contiguously_hashable<T>::value>::type
+hash_append(HashAlgorithm& h, const std::vector<T, Alloc>& v)
+{
+    h(v.data(), v.size() * sizeof(T));
+    hash_append(h, v.size());
+}
+
+template <class HashAlgorithm, class T, class Alloc>
+typename std::enable_if<!is_contiguously_hashable<T>::value>::type
+hash_append(HashAlgorithm& h, const std::vector<T, Alloc>& v)
+{
+    for (const auto& val : v)
+        hash_append(h, val);
+    hash_append(h, v.size());
 }
 
 template <class HashAlgorithm, class T1, class T2, class... Ts>

--- a/include/meta/hashing/hash.h
+++ b/include/meta/hashing/hash.h
@@ -301,6 +301,39 @@ inline uint64_t get_process_seed()
 }
 
 /**
+ * A generic, manually seeded hash function.
+ */
+template <class HashAlgorithm = typename default_hasher<>::type,
+          class SeedType = uint64_t>
+class seeded_hash
+{
+  public:
+    using result_type = typename HashAlgorithm::result_type;
+
+    seeded_hash(SeedType seed) : seed_{seed}
+    {
+        // nothing
+    }
+
+    template <class T>
+    result_type operator()(const T& t) const
+    {
+        HashAlgorithm h(seed_);
+        using hashing::hash_append;
+        hash_append(h, t);
+        return static_cast<result_type>(h);
+    }
+
+    SeedType seed() const
+    {
+        return seed_;
+    }
+
+  private:
+    SeedType seed_;
+};
+
+/**
  * A generic, randomly seeded hash function.
  * @see
  * http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n3980.html#seeding

--- a/include/meta/hashing/perfect_hash_builder.tcc
+++ b/include/meta/hashing/perfect_hash_builder.tcc
@@ -394,9 +394,9 @@ void hashes_to_indices(ForwardIterator begin, ForwardIterator end,
                    });
 }
 
-bool insert_bucket(std::vector<std::size_t>& indices,
-                   std::vector<bool>& occupied_slots, std::size_t idx,
-                   uint16_t seed, util::disk_vector<uint16_t>& seeds)
+inline bool insert_bucket(std::vector<std::size_t>& indices,
+                          std::vector<bool>& occupied_slots, std::size_t idx,
+                          uint16_t seed, util::disk_vector<uint16_t>& seeds)
 {
     auto iit = indices.begin();
     for (; iit != indices.end(); ++iit)

--- a/include/meta/hashing/perfect_hash_map.h
+++ b/include/meta/hashing/perfect_hash_map.h
@@ -1,0 +1,355 @@
+/**
+ * @file perfect_hash_map.h
+ * @author Chase Geigle
+ *
+ * All files in META are dual-licensed under the MIT and NCSA licenses. For more
+ * details, consult the file LICENSE.mit and LICENSE.ncsa in the root of the
+ * project.
+ */
+
+#ifndef META_HASHING_PERFECT_HASH_MAP_H_
+#define META_HASHING_PERFECT_HASH_MAP_H_
+
+#include <cstdint>
+
+#include "meta/hashing/perfect_hash.h"
+#include "meta/hashing/perfect_hash_builder.h"
+#include "meta/io/moveable_stream.h"
+#include "meta/io/mmap_file.h"
+#include "meta/io/filesystem.h"
+#include "meta/util/optional.h"
+#include "meta/util/progress.h"
+
+namespace meta
+{
+namespace hashing
+{
+
+namespace detail
+{
+template <class Value, class FingerPrint = uint32_t>
+struct hash_record
+{
+    using fingerprint_type = FingerPrint;
+    using value_type = Value;
+    FingerPrint id;
+    Value value;
+};
+
+template <class Value, class FingerPrint = uint32_t>
+struct hashed_value
+{
+    uint64_t idx;
+    hash_record<Value, FingerPrint> record;
+
+    void merge_with(hashed_value&&)
+    {
+        throw std::runtime_error{"can't merge detail::hashed_value"};
+    }
+};
+
+template <class OutputStream, class Value, class FingerPrint>
+uint64_t packed_write(OutputStream& os,
+                      const hash_record<Value, FingerPrint>& r)
+{
+    using io::packed::write;
+    return write(os, r.id) + write(os, r.value);
+}
+
+template <class InputStream, class Value, class FingerPrint>
+uint64_t packed_read(InputStream& is, hash_record<Value, FingerPrint>& r)
+{
+    using io::packed::read;
+    return read(is, r.id) + read(is, r.value);
+}
+
+template <class OutputStream, class Value, class FingerPrint>
+uint64_t packed_write(OutputStream& os,
+                      const hashed_value<Value, FingerPrint>& hv)
+{
+    using io::packed::write;
+    return write(os, hv.idx) + write(os, hv.record);
+}
+
+template <class InputStream, class Value, class FingerPrint>
+uint64_t packed_read(InputStream& is, hashed_value<Value, FingerPrint>& hv)
+{
+    using io::packed::write;
+    return read(is, hv.idx) + read(is, hv.record);
+}
+
+template <class HashedValue>
+class hv_chunk_iterator
+{
+  public:
+    hv_chunk_iterator() = default;
+
+    hv_chunk_iterator(const std::string& filename)
+        : input_{filename, std::ios::binary},
+          bytes_read_{0},
+          total_bytes_{filesystem::file_size(filename)}
+    {
+        ++(*this);
+    }
+
+    hv_chunk_iterator& operator++()
+    {
+        if (input_.stream().peek() == EOF)
+        {
+            input_.stream().close();
+
+            assert(*this == hv_chunk_iterator{});
+            return *this;
+        }
+
+        bytes_read_ += io::packed::read(input_.stream(), record_.idx);
+        bytes_read_ += io::packed::read(input_.stream(), record_.record);
+        return *this;
+    }
+
+    HashedValue& operator*()
+    {
+        return record_;
+    }
+
+    const HashedValue& operator*() const
+    {
+        return record_;
+    }
+
+    uint64_t total_bytes() const
+    {
+        return total_bytes_;
+    }
+
+    uint64_t bytes_read() const
+    {
+        return bytes_read_;
+    }
+
+    bool operator==(const hv_chunk_iterator& other) const
+    {
+        return !input_.stream().is_open() && !other.input_.stream().is_open();
+    }
+
+  private:
+    io::mifstream input_;
+    HashedValue record_;
+    uint64_t bytes_read_;
+    uint64_t total_bytes_;
+};
+
+template <class HashedValue>
+bool operator!=(const hv_chunk_iterator<HashedValue>& a,
+                const hv_chunk_iterator<HashedValue>& b)
+{
+    return !(a == b);
+}
+}
+
+template <class KeyType, class ValueType, class FingerPrint = uint32_t>
+class perfect_hash_map_builder
+{
+  public:
+    using record_type = detail::hash_record<ValueType, FingerPrint>;
+    using fingerprint_type = typename record_type::fingerprint_type;
+    using hash_builder_type = hashing::perfect_hash_builder<KeyType>;
+    using options_type = typename hash_builder_type::options;
+    using fingerprint_hash = hashing::seeded_hash<hashing::farm_hash_seeded>;
+
+    perfect_hash_map_builder(const options_type& options)
+        : options_{options},
+          output_{options.prefix + "/values.bin.tmp", std::ios::binary},
+          hash_builder_{make_unique<hash_builder_type>(options)},
+          fingerprint_{47}
+    {
+        // nothing
+    }
+
+    void operator()(const KeyType& key, const ValueType& value)
+    {
+        (*hash_builder_)(key);
+
+        io::packed::write(output_.stream(), key);
+        io::packed::write(output_.stream(), value);
+    }
+
+    void write()
+    {
+        output_.stream().close();
+
+        LOG(progress) << "> Building hash function...\n" << ENDLG;
+        hash_builder_->write();
+        hash_builder_ = nullptr;
+
+        reorder_values();
+    }
+
+  private:
+    using hashed_value = detail::hashed_value<ValueType>;
+
+    void reorder_values()
+    {
+        // hash every (key, value) we recorded using the perfect hash
+        // function we generated in the first pass, then do a multi-way
+        // merge to put the values into the right order according to the
+        // new hash function
+        LOG(info) << "Loading hash..." << ENDLG;
+        hashing::perfect_hash<KeyType> hash{options_.prefix};
+        LOG(info) << "Hash loaded" << ENDLG;
+
+        uint64_t num_chunks = 0;
+
+        {
+            std::vector<hashed_value> buffer;
+            buffer.reserve(options_.max_ram / sizeof(hashed_value));
+
+            printing::progress progress{
+                " > Reordering values: ",
+                filesystem::file_size(options_.prefix + "/values.bin.tmp")};
+
+            std::ifstream input{options_.prefix + "/values.bin.tmp",
+                                std::ios::binary};
+
+            for (uint64_t bytes = 0; input.peek() != EOF;)
+            {
+                progress(bytes);
+
+                KeyType key;
+                hashed_value h_value;
+                bytes += io::packed::read(input, key);
+                bytes += io::packed::read(input, h_value.record.value);
+                h_value.record.id
+                    = static_cast<fingerprint_type>(fingerprint_(key));
+                h_value.idx = hash(key);
+
+                buffer.push_back(h_value);
+
+                if (buffer.size() == options_.max_ram / sizeof(hashed_value))
+                {
+                    flush_chunk(buffer, num_chunks);
+                    ++num_chunks;
+                }
+            }
+
+            if (!buffer.empty())
+            {
+                flush_chunk(buffer, num_chunks);
+                ++num_chunks;
+            }
+        }
+
+        filesystem::remove_all(options_.prefix + "/values.bin.tmp");
+
+        std::vector<detail::hv_chunk_iterator<hashed_value>> iterators;
+        iterators.reserve(num_chunks);
+        for (uint64_t i = 0; i < num_chunks; ++i)
+            iterators.emplace_back(options_.prefix + "/value-chunk."
+                                   + std::to_string(i));
+
+        std::ofstream output{options_.prefix + "/values.bin", std::ios::binary};
+        util::multiway_merge(
+            iterators.begin(), iterators.end(),
+            // sort records at head of chunks by decreasing hash id
+            [](const hashed_value& a, const hashed_value& b)
+            {
+                return a.idx < b.idx;
+            },
+            // never merge two records together
+            [](const hashed_value&, const hashed_value&)
+            {
+                return false;
+            },
+            [&](hashed_value&& hv)
+            {
+                output.write(reinterpret_cast<char*>(&hv.record),
+                             sizeof(hv.record));
+            });
+
+        // delete temporary files
+        for (uint64_t i = 0; i < num_chunks; ++i)
+        {
+            filesystem::delete_file(options_.prefix + "/value-chunk."
+                                    + std::to_string(i));
+        }
+    }
+
+    void flush_chunk(std::vector<hashed_value>& buffer, uint64_t chunk_num)
+    {
+        std::sort(buffer.begin(), buffer.end(),
+                  [](const hashed_value& a, const hashed_value& b)
+                  {
+                      return a.idx < b.idx;
+                  });
+
+        std::ofstream chunk{options_.prefix + "/value-chunk."
+                            + std::to_string(chunk_num)};
+        for (const auto& hval : buffer)
+        {
+            io::packed::write(chunk, hval.idx);
+            io::packed::write(chunk, hval.record);
+        }
+        buffer.clear();
+    }
+
+    options_type options_;
+    io::mofstream output_;
+    std::unique_ptr<hash_builder_type> hash_builder_;
+    fingerprint_hash fingerprint_;
+};
+
+template <class Key, class Value, class FingerPrint = uint32_t>
+class perfect_hash_map
+{
+  public:
+    using fingerprint_type = FingerPrint;
+    using record_type = detail::hash_record<Value, FingerPrint>;
+    using fingerprint_hash = seeded_hash<hashing::farm_hash_seeded>;
+
+    perfect_hash_map(const std::string& prefix)
+        : hash_{prefix}, file_{prefix + "/values.bin"}, fingerprint_{47}
+    {
+        // nothing
+    }
+
+    const perfect_hash<Key>& hash() const
+    {
+        return hash_;
+    }
+
+    util::optional<uint64_t> index(const Key& key) const
+    {
+        auto idx = hash_(key);
+        auto id = static_cast<fingerprint_type>(fingerprint_(key));
+
+        auto record = reinterpret_cast<const record_type*>(
+            file_.begin() + idx * sizeof(record_type));
+
+        if (id == record->id)
+            return idx;
+
+        return util::nullopt;
+    }
+
+    util::optional<Value> at(const Key& key) const
+    {
+        auto idx = hash_(key);
+        auto id = static_cast<fingerprint_type>(fingerprint_(key));
+
+        auto record = reinterpret_cast<const record_type*>(
+            file_.begin() + idx * sizeof(record_type));
+
+        if (id == record->id)
+            return record->value;
+
+        return util::nullopt;
+    }
+
+  private:
+    perfect_hash<Key> hash_;
+    io::mmap_file file_;
+    fingerprint_hash fingerprint_;
+};
+}
+}
+#endif

--- a/include/meta/hashing/perfect_hash_map.h
+++ b/include/meta/hashing/perfect_hash_map.h
@@ -235,7 +235,7 @@ class perfect_hash_map_builder
 };
 
 template <class Value>
-struct index_and_value
+struct indexed_value
 {
     uint64_t idx;
     Value value;
@@ -248,7 +248,7 @@ class perfect_hash_map
     using fingerprint_type = FingerPrint;
     using record_type = detail::hash_record<Value, FingerPrint>;
     using fingerprint_hash = seeded_hash<hashing::farm_hash_seeded>;
-    using index_and_value_type = index_and_value<Value>;
+    using index_and_value_type = indexed_value<Value>;
 
     perfect_hash_map(const std::string& prefix)
         : hash_{prefix}, file_{prefix + "/values.bin"}, fingerprint_{47}

--- a/include/meta/hashing/perfect_hash_map.h
+++ b/include/meta/hashing/perfect_hash_map.h
@@ -158,7 +158,7 @@ class perfect_hash_map_builder
     using fingerprint_hash = hashing::seeded_hash<hashing::farm_hash_seeded>;
 
     perfect_hash_map_builder(const options_type& options)
-        : options_{options},
+        : options_(options),
           output_{options.prefix + "/values.bin.tmp", std::ios::binary},
           hash_builder_{make_unique<hash_builder_type>(options)},
           fingerprint_{47}

--- a/include/meta/io/packed.h
+++ b/include/meta/io/packed.h
@@ -386,6 +386,7 @@ uint64_t read(InputStream& is, T& value)
 template <class T, class InputStream>
 T read(InputStream& stream)
 {
+    using meta::io::packed::packed_read;
     T val;
     packed_read(stream, val);
     return val;

--- a/include/meta/io/packed.h
+++ b/include/meta/io/packed.h
@@ -38,7 +38,7 @@ typename std::enable_if<!std::is_floating_point<T>::value
                             && std::is_unsigned<T>::value
                             && !std::is_same<T, bool>::value,
                         uint64_t>::type
-write(OutputStream& stream, T value)
+packed_write(OutputStream& stream, T value)
 {
     uint64_t size = 0;
     while (value > 127)
@@ -58,10 +58,10 @@ write(OutputStream& stream, T value)
  */
 template <class OutputStream, class T>
 typename std::enable_if<std::is_same<T, bool>::value, uint64_t>::type
-write(OutputStream& stream, T value)
+packed_write(OutputStream& stream, T value)
 {
     uint8_t val = value ? 1 : 0;
-    return write(stream, val);
+    return packed_write(stream, val);
 }
 
 /**
@@ -79,12 +79,12 @@ template <class OutputStream, class T>
 typename std::enable_if<!std::is_floating_point<T>::value
                             && std::is_signed<T>::value,
                         uint64_t>::type
-write(OutputStream& stream, T value)
+packed_write(OutputStream& stream, T value)
 {
     using usigned_type = typename std::make_unsigned<T>::type;
     auto elem = static_cast<usigned_type>((value << 1)
                                           ^ (value >> (sizeof(T) * 8 - 1)));
-    return write(stream, elem);
+    return packed_write(stream, elem);
 }
 
 /**
@@ -103,7 +103,7 @@ write(OutputStream& stream, T value)
  */
 template <class OutputStream, class T>
 typename std::enable_if<std::is_floating_point<T>::value, uint64_t>::type
-write(OutputStream& stream, T value)
+packed_write(OutputStream& stream, T value)
 {
     int exp;
     auto digits = std::numeric_limits<T>::digits;
@@ -119,8 +119,8 @@ write(OutputStream& stream, T value)
         exponent += 8;
     }
 
-    auto bytes = write(stream, mantissa);
-    bytes += write(stream, exponent);
+    auto bytes = packed_write(stream, mantissa);
+    bytes += packed_write(stream, exponent);
     return bytes;
 }
 
@@ -134,7 +134,7 @@ write(OutputStream& stream, T value)
  * @return the number of bytes used to write out the value
  */
 template <class OutputStream>
-uint64_t write(OutputStream& stream, util::string_view value)
+uint64_t packed_write(OutputStream& stream, util::string_view value)
 {
     for (const auto& c : value)
     {
@@ -154,10 +154,10 @@ uint64_t write(OutputStream& stream, util::string_view value)
  */
 template <class OutputStream, class T>
 typename std::enable_if<std::is_enum<T>::value, uint64_t>::type
-write(OutputStream& stream, T value)
+packed_write(OutputStream& stream, T value)
 {
     auto val = static_cast<typename std::underlying_type<T>::type>(value);
-    return write(stream, val);
+    return packed_write(stream, val);
 }
 
 /**
@@ -169,9 +169,38 @@ write(OutputStream& stream, T value)
  * @return the number of bytes used to write out the value
  */
 template <class OutputStream, class Tag, class T>
-uint64_t write(OutputStream& stream, const util::identifier<Tag, T>& value)
+uint64_t packed_write(OutputStream& stream, const util::identifier<Tag, T>& value)
 {
-    return write(stream, static_cast<const T&>(value));
+    return packed_write(stream, static_cast<const T&>(value));
+}
+
+/**
+ * Writes a vector type in a packed representation.
+ *
+ * @param os The stream to write to
+ * @param value The value to write
+ * @return the number of bytes used to write out the value
+ */
+template <class OutputStream, class T, class Alloc>
+uint64_t packed_write(OutputStream& os, const std::vector<T, Alloc>& vec)
+{
+    auto bytes = packed_write(os, vec.size());
+    for (const auto& v : vec)
+        bytes += packed_write(os, v);
+    return bytes;
+}
+
+/**
+ * Wrapper function for enabling ADL for io::packed::write.
+ * @param os The stream to write to
+ * @param value The value to write
+ * @return the number of bytes used to write out the value
+ */
+template <class OutputStream, class T>
+uint64_t write(OutputStream& os, const T& value)
+{
+    using meta::io::packed::packed_write;
+    return packed_write(os, value);
 }
 
 /**
@@ -186,7 +215,7 @@ typename std::enable_if<!std::is_floating_point<T>::value
                             && std::is_unsigned<T>::value
                             && !std::is_same<T, bool>::value,
                         uint64_t>::type
-read(InputStream& stream, T& value)
+packed_read(InputStream& stream, T& value)
 {
     value = 0;
     uint64_t size = 0;
@@ -209,10 +238,10 @@ read(InputStream& stream, T& value)
  */
 template <class InputStream, class T>
 typename std::enable_if<std::is_same<T, bool>::value, uint64_t>::type
-read(InputStream& stream, T& value)
+packed_read(InputStream& stream, T& value)
 {
     uint8_t byte;
-    auto bytes = read(stream, byte);
+    auto bytes = packed_read(stream, byte);
     value = byte > 0;
     return bytes;
 }
@@ -232,10 +261,10 @@ template <class InputStream, class T>
 typename std::enable_if<!std::is_floating_point<T>::value
                             && std::is_signed<T>::value,
                         uint64_t>::type
-read(InputStream& stream, T& value)
+packed_read(InputStream& stream, T& value)
 {
     typename std::make_unsigned<T>::type elem;
-    auto bytes = read(stream, elem);
+    auto bytes = packed_read(stream, elem);
 
     value = (elem >> 1) ^ (-(elem & 1));
 
@@ -251,13 +280,13 @@ read(InputStream& stream, T& value)
  */
 template <class InputStream, class T>
 typename std::enable_if<std::is_floating_point<T>::value, uint64_t>::type
-read(InputStream& stream, T& value)
+packed_read(InputStream& stream, T& value)
 {
     int64_t mantissa;
     int64_t exponent;
 
-    auto bytes = read(stream, mantissa);
-    bytes += read(stream, exponent);
+    auto bytes = packed_read(stream, mantissa);
+    bytes += packed_read(stream, exponent);
     value = static_cast<T>(mantissa * std::pow(2.0, exponent));
     return bytes;
 }
@@ -270,7 +299,7 @@ read(InputStream& stream, T& value)
  * @return the number of bytes read
  */
 template <class InputStream>
-uint64_t read(InputStream& stream, std::string& value)
+uint64_t packed_read(InputStream& stream, std::string& value)
 {
     value.clear();
     for (auto c = stream.get(); c != '\0'; c = stream.get())
@@ -288,10 +317,10 @@ uint64_t read(InputStream& stream, std::string& value)
  */
 template <class InputStream, class T>
 typename std::enable_if<std::is_enum<T>::value, uint64_t>::type
-read(InputStream& stream, T& value)
+packed_read(InputStream& stream, T& value)
 {
     typename std::underlying_type<T>::type val;
-    auto size = read(stream, val);
+    auto size = packed_read(stream, val);
     value = static_cast<T>(val);
     return size;
 }
@@ -305,9 +334,48 @@ read(InputStream& stream, T& value)
  * @return the number of bytes used to write out the value
  */
 template <class InputStream, class Tag, class T>
-uint64_t read(InputStream& stream, util::identifier<Tag, T>& value)
+uint64_t packed_read(InputStream& stream, util::identifier<Tag, T>& value)
 {
-    return read(stream, static_cast<T&>(value));
+    return packed_read(stream, static_cast<T&>(value));
+}
+
+/**
+ * Reads a vector type from a packed representation.
+ *
+ * @param is The stream to read from
+ * @param value The value to write
+ * @return the number of bytes read
+ */
+template <class InputStream, class T, class Alloc>
+uint64_t packed_read(InputStream& is, std::vector<T, Alloc>& vec)
+{
+    uint64_t size;
+    auto bytes = packed_read(is, size);
+    vec.clear();
+    vec.reserve(size);
+
+    for (uint64_t i = 0; i < size; ++i)
+    {
+        T val;
+        bytes += packed_read(is, val);
+        vec.emplace_back(val);
+    }
+    assert(vec.size() == size);
+    return bytes;
+}
+
+/**
+ * Wrapper function for enabling ADL for io::packed::read.
+ *
+ * @param is The stream to read from
+ * @param value The value to write
+ * @return the number of bytes read
+ */
+template <class InputStream, class T>
+uint64_t read(InputStream& is, T& value)
+{
+    using meta::io::packed::packed_read;
+    return packed_read(is, value);
 }
 
 /**
@@ -319,7 +387,7 @@ template <class T, class InputStream>
 T read(InputStream& stream)
 {
     T val;
-    read(stream, val);
+    packed_read(stream, val);
     return val;
 }
 }

--- a/include/meta/lm/language_model.h
+++ b/include/meta/lm/language_model.h
@@ -10,11 +10,13 @@
 #ifndef META_LANGUAGE_MODEL_H_
 #define META_LANGUAGE_MODEL_H_
 
-#include <vector>
 #include <memory>
-#include <unordered_map>
 #include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "cpptoml.h"
+#include "meta/lm/lm_state.h"
 #include "meta/lm/sentence.h"
 #include "meta/lm/static_probe_map.h"
 #include "meta/lm/token_list.h"
@@ -95,6 +97,11 @@ class language_model
     std::vector<std::pair<std::string, float>> top_k(const sentence& prev,
                                                      size_t k) const;
 
+    uint64_t index(const std::string& token) const;
+
+    float score(const lm_state& in_state, uint64_t token,
+                lm_state& out_state) const;
+
   private:
     /**
      * Reads precomputed LM data into this object.
@@ -168,6 +175,8 @@ class language_model
     std::unordered_map<std::string, term_id> vocabulary_;
 
     std::string prefix_;
+
+    uint64_t unk_id_;
 
     lm_node unk_node_;
 };

--- a/include/meta/lm/language_model.h
+++ b/include/meta/lm/language_model.h
@@ -102,12 +102,12 @@ class language_model
      * @param token The unigram to look up
      * @return the vocabulary id for this token
      */
-    uint64_t index(const std::string& token) const;
+    term_id index(const std::string& token) const;
 
     /**
      * @return the vocabulary id for the <unk> token
      */
-    uint64_t unk() const;
+    term_id unk() const;
 
     /**
      * Returns the score according to the language model for generating
@@ -121,7 +121,7 @@ class language_model
      *
      * @return \f$p(w_n \mid w_1, \ldots, w_{n-1})\f$
      */
-    float score(const lm_state& in_state, uint64_t token,
+    float score(const lm_state& in_state, term_id token,
                 lm_state& out_state) const;
 
   private:
@@ -149,7 +149,7 @@ class language_model
 
     std::string prefix_;
 
-    uint64_t unk_id_;
+    term_id unk_id_;
 
     lm_node unk_node_;
 };

--- a/include/meta/lm/language_model.h
+++ b/include/meta/lm/language_model.h
@@ -132,55 +132,6 @@ class language_model
     void read_arpa_format(const std::string& arpa_file);
 
     /**
-     * @param tokens
-     * @return the log probability of one ngram
-     */
-    float prob_calc(token_list tokens) const;
-
-    /**
-     * @param begin The beginning of the list of tokens to score
-     * @param end The ending of the list of tokens to score
-     * @return the log probability of one ngram
-     */
-    template <class BidirectionalIterator>
-    float prob_calc(BidirectionalIterator begin,
-                    BidirectionalIterator end) const
-    {
-        auto size = static_cast<std::size_t>(std::distance(begin, end));
-        if (size == 0)
-            throw language_model_exception{"prob_calc: tokens is empty!"};
-
-        if (size == 1)
-        {
-            auto opt = lm_[0].find(begin, end);
-            if (opt)
-                return opt->prob;
-            return unk_node_.prob;
-        }
-        else
-        {
-            auto opt = lm_[size - 1].find(begin, end);
-            if (opt)
-                return opt->prob;
-
-            if (size - 1 == 1)
-            {
-                // look up history [begin, end - 1)
-                auto opt = lm_[0].find(begin, end - 1);
-                if (!opt)
-                    opt = unk_node_;
-            }
-
-            // opt might have been set above
-            if (!opt)
-                opt = lm_[size - 2].find(begin, end - 1);
-            if (opt)
-                return opt->backoff + prob_calc(begin + 1, end);
-            return prob_calc(begin + 1, end);
-        }
-    }
-
-    /**
      * Internal log_prob that takes a token_list
      */
     float log_prob(const token_list& tokens) const;

--- a/include/meta/lm/language_model.h
+++ b/include/meta/lm/language_model.h
@@ -97,10 +97,30 @@ class language_model
     std::vector<std::pair<std::string, float>> top_k(const sentence& prev,
                                                      size_t k) const;
 
+    /**
+     * Convert a unigram into its vocabulary id.
+     * @param token The unigram to look up
+     * @return the vocabulary id for this token
+     */
     uint64_t index(const std::string& token) const;
 
+    /**
+     * @return the vocabulary id for the <unk> token
+     */
     uint64_t unk() const;
 
+    /**
+     * Returns the score according to the language model for generating
+     * the next token given the current state in_state. The context needed
+     * for scoring the next word is written to out_state.
+     *
+     * @param in_state The context, which is either just <s> or was
+     * filled for you by a previous call to score()
+     * @param token The next token to score (as a word index)
+     * @param out_state Storage to write the state for the next query to
+     *
+     * @return \f$p(w_n \mid w_1, \ldots, w_{n-1})\f$
+     */
     float score(const lm_state& in_state, uint64_t token,
                 lm_state& out_state) const;
 

--- a/include/meta/lm/language_model.h
+++ b/include/meta/lm/language_model.h
@@ -99,6 +99,8 @@ class language_model
 
     uint64_t index(const std::string& token) const;
 
+    uint64_t unk() const;
+
     float score(const lm_state& in_state, uint64_t token,
                 lm_state& out_state) const;
 

--- a/include/meta/lm/lm_state.h
+++ b/include/meta/lm/lm_state.h
@@ -14,13 +14,15 @@
 #include <cstdint>
 #include <vector>
 
+#include "meta/meta.h"
+
 namespace meta
 {
 namespace lm
 {
 struct lm_state
 {
-    std::vector<uint64_t> previous;
+    std::vector<term_id> previous;
 
     void shrink()
     {

--- a/include/meta/lm/lm_state.h
+++ b/include/meta/lm/lm_state.h
@@ -1,0 +1,33 @@
+/**
+ * @file lm_state.h
+ * @author Chase Geigle
+ *
+ * All files in META are dual-licensed under the MIT and NCSA licenses. For more
+ * details, consult the file LICENSE.mit and LICENSE.ncsa in the root of the
+ * project.
+ */
+
+#ifndef META_LM_LM_STATE_H_
+#define META_LM_LM_STATE_H_
+
+#include <algorithm>
+#include <cstdint>
+#include <vector>
+
+namespace meta
+{
+namespace lm
+{
+struct lm_state
+{
+    std::vector<uint64_t> previous;
+
+    void shrink()
+    {
+        std::copy(previous.begin() + 1, previous.end(), previous.begin());
+        previous.pop_back();
+    }
+};
+}
+}
+#endif

--- a/include/meta/lm/mph_language_model.h
+++ b/include/meta/lm/mph_language_model.h
@@ -14,7 +14,6 @@
 #include "meta/lm/lm_state.h"
 #include "meta/lm/ngram_map.h"
 #include "meta/lm/sentence.h"
-#include "meta/lm/token_list.h"
 #include "meta/util/string_view.h"
 
 namespace meta

--- a/include/meta/lm/mph_language_model.h
+++ b/include/meta/lm/mph_language_model.h
@@ -96,7 +96,6 @@ class mph_language_model
      *
      * @return \f$p(w_n \mid w_1, \ldots, w_{n-1})\f$
      */
-
     float score(const lm_state& in_state, uint64_t token,
                 lm_state& out_state) const;
 

--- a/include/meta/lm/mph_language_model.h
+++ b/include/meta/lm/mph_language_model.h
@@ -14,7 +14,7 @@
 #include "meta/lm/ngram_map.h"
 #include "meta/lm/sentence.h"
 #include "meta/lm/token_list.h"
-#include "meta/util/array_view.h"
+#include "meta/util/string_view.h"
 
 namespace meta
 {
@@ -68,8 +68,44 @@ class mph_language_model
 
     ~mph_language_model();
 
-    float score(const lm_state& in_state, const std::string& token,
+    /**
+     * Determines to word index in the unigram table for this term.
+     * @param token The unigram to look up
+     */
+    uint64_t index(util::string_view token) const;
+
+    /**
+     * @return the word index of the <unk> token.
+     */
+    uint64_t unk() const;
+
+    /**
+     * Returns the score according to the language model for generating
+     * the next token given the current state in_state. The context needed
+     * for scoring the next word is written to out_state.
+     *
+     * @param in_state The context, which is either just <s> or was
+     * filled for you by a previous call to score()
+     * @param token The next token to score (as a string)
+     * @param out_state Storage to write the state for the next query to
+     *
+     * @return \f$p(w_n \mid w_1, \ldots, w_{n-1})\f$
+     */
+    float score(const lm_state& in_state, util::string_view token,
                 lm_state& out_state) const;
+
+    /**
+     * Returns the score according to the language model for generating
+     * the next token given the current state in_state. The context needed
+     * for scoring the next word is written to out_state.
+     *
+     * @param in_state The context, which is either just <s> or was
+     * filled for you by a previous call to score()
+     * @param token The next token to score (as a word index)
+     * @param out_state Storage to write the state for the next query to
+     *
+     * @return \f$p(w_n \mid w_1, \ldots, w_{n-1})\f$
+     */
 
     float score(const lm_state& in_state, uint64_t token,
                 lm_state& out_state) const;

--- a/include/meta/lm/mph_language_model.h
+++ b/include/meta/lm/mph_language_model.h
@@ -1,0 +1,92 @@
+/**
+ * @file mph_language_model.h
+ * @author Chase Geigle
+ *
+ * All files in META are dual-licensed under the MIT and NCSA licenses. For more
+ * details, consult the file LICENSE.mit and LICENSE.ncsa in the root of the
+ * project.
+ */
+
+#ifndef META_LM_MPH_LANGUAGE_MODEL_H_
+#define META_LM_MPH_LANGUAGE_MODEL_H_
+
+#include "cpptoml.h"
+#include "meta/lm/sentence.h"
+#include "meta/lm/token_list.h"
+#include "meta/util/array_view.h"
+
+namespace meta
+{
+namespace lm
+{
+
+/**
+ * An ngram language model class based on a collection of minimal perfect
+ * hash functions and dense value arrays. The modle generates minimal
+ * perfect hash functions for each order in linear time, facilitating
+ * \f$O(1)\f$ lookup time for any ngram of any order whilst using very
+ * little space per ngram. Currently, estimation of the language model is
+ * not implemented. We recommend using KenLM to generate a .arpa file from
+ * a text corpus that has been (optionally) preprocessed by MeTA.
+ *
+ * @see http://www.speech.sri.com/projects/srilm/manpages/ngram-format.5.html
+ * @see https://kheafield.com/code/kenlm/
+ *
+ * Required config parameters:
+ * ~~~toml
+ * [language-model]
+ * binary-file-prefix = "path-to-binary-files"
+ * # only this key is needed if the LM is already binarized
+ * ~~~
+ *
+ * Optional config parameters:
+ * ~~~toml
+ * [language-model]
+ * arpa-file = "path-to-arpa-file" # if no binary files have yet been created
+ * ~~~
+ */
+class mph_language_model
+{
+  public:
+    /**
+    * Creates an N-gram language model based on the corpus specified in the
+    * config file.
+    */
+    mph_language_model(const cpptoml::table& config);
+
+#if 0
+
+    /**
+     * Default move constructor.
+     */
+    mph_language_model(mph_language_model&&) = default;
+
+    /**
+     * @param sentence A sequence of tokens
+     * @return the perplexity of this token sequence given the current language
+     * model: \f$ \sqrt[n]{\prod_{i=1}^n\frac{1}{p(w_i|w_{i-n}\cdots w_{i-1})}}
+     * \f$
+     */
+    float perplexity(const sentence& tokens) const;
+
+    /**
+     * @param sentence A sequence of tokens
+     * @return the perplexity of this token sequence given the current language
+     * model normalized by the length of the sequence
+     */
+    float perplexity_per_word(const sentence& tokens) const;
+
+    /**
+     * @param tokens A sequence of n tokens (one sentence)
+     * @return the log probability of the likelihood of this sentence
+     */
+    float log_prob(const sentence& tokens) const;
+
+  private:
+    struct impl;
+    std::unique_ptr<impl> impl_;
+#endif
+};
+}
+}
+#endif

--- a/include/meta/lm/mph_language_model.h
+++ b/include/meta/lm/mph_language_model.h
@@ -61,12 +61,12 @@ class mph_language_model
      * Determines to word index in the unigram table for this term.
      * @param token The unigram to look up
      */
-    uint64_t index(util::string_view token) const;
+    term_id index(util::string_view token) const;
 
     /**
      * @return the word index of the <unk> token.
      */
-    uint64_t unk() const;
+    term_id unk() const;
 
     /**
      * Returns the score according to the language model for generating
@@ -95,11 +95,11 @@ class mph_language_model
      *
      * @return \f$p(w_n \mid w_1, \ldots, w_{n-1})\f$
      */
-    float score(const lm_state& in_state, uint64_t token,
+    float score(const lm_state& in_state, term_id token,
                 lm_state& out_state) const;
 
   private:
-    float score(const lm_state& in_state, uint64_t token, prob_backoff<> pb,
+    float score(const lm_state& in_state, term_id token, prob_backoff<> pb,
                 lm_state& out_state) const;
 
     struct impl;

--- a/include/meta/lm/mph_language_model.h
+++ b/include/meta/lm/mph_language_model.h
@@ -11,6 +11,7 @@
 #define META_LM_MPH_LANGUAGE_MODEL_H_
 
 #include "cpptoml.h"
+#include "meta/lm/lm_state.h"
 #include "meta/lm/ngram_map.h"
 #include "meta/lm/sentence.h"
 #include "meta/lm/token_list.h"
@@ -20,17 +21,6 @@ namespace meta
 {
 namespace lm
 {
-
-struct lm_state
-{
-    std::vector<uint64_t> previous;
-
-    void shrink()
-    {
-        std::copy(previous.begin() + 1, previous.end(), previous.begin());
-        previous.pop_back();
-    }
-};
 
 /**
  * An ngram language model class based on a collection of minimal perfect

--- a/include/meta/lm/ngram_map.h
+++ b/include/meta/lm/ngram_map.h
@@ -1,0 +1,51 @@
+/**
+ * @file ngram_map.h
+ * @author Chase Geigle
+ *
+ * All files in META are dual-licensed under the MIT and NCSA licenses. For more
+ * details, consult the file LICENSE.mit and LICENSE.ncsa in the root of the
+ * project.
+ */
+
+#ifndef META_LM_NGRAM_MAP_H_
+#define META_LM_NGRAM_MAP_H_
+
+#include <cstdint>
+
+#include "meta/io/packed.h"
+#include "meta/hashing/perfect_hash_map.h"
+
+namespace meta
+{
+namespace lm
+{
+template <class Prob = float, class Backoff = float>
+struct prob_backoff
+{
+    Prob prob;
+    Backoff backoff;
+};
+
+template <class OutputStream, class Prob, class Backoff>
+uint64_t packed_write(OutputStream& os, const lm::prob_backoff<Prob, Backoff>& pb)
+{
+    return io::packed::write(os, pb.prob) + io::packed::write(os, pb.backoff);
+}
+
+template <class InputStream, class Prob, class Backoff>
+uint64_t packed_read(InputStream& is, lm::prob_backoff<Prob, Backoff>& pb)
+{
+    return io::packed::read(is, pb.prob) + io::packed::read(is, pb.backoff);
+}
+
+template <class KeyType, class ValueType = prob_backoff<>,
+          class FingerPrint = uint32_t>
+using ngram_map_builder
+    = hashing::perfect_hash_map_builder<KeyType, ValueType, FingerPrint>;
+
+template <class KeyType, class ValueType = prob_backoff<>,
+          class FingerPrint = uint32_t>
+using ngram_map = hashing::perfect_hash_map<KeyType, ValueType, FingerPrint>;
+}
+}
+#endif

--- a/include/meta/lm/read_arpa.h
+++ b/include/meta/lm/read_arpa.h
@@ -1,0 +1,79 @@
+/**
+ * @file read_arpa.h
+ * @author Chase Geigle
+ *
+ * All files in META are dual-licensed under the MIT and NCSA licenses. For more
+ * details, consult the file LICENSE.mit and LICENSE.ncsa in the root of the
+ * project.
+ */
+
+#ifndef META_LM_READ_ARPA_H_
+#define META_LM_READ_ARPA_H_
+
+#include <fstream>
+#include <string>
+
+namespace meta
+{
+namespace lm
+{
+
+/**
+ * Parses an ARPA formatted language model file.
+ *
+ * @param count_handler A callback function to be invoked when reading the
+ * ngram count information from the file, of the form (order, count),
+ * where order is **0-indexed**.
+ * @param ngram_handler A callback function to be invoked when reading the
+ * ngram statistics themselves, of the form (order, ngram, prob, backoff),
+ * where order is **0-indexed**.
+ */
+template <class CountHandler, class NGramHandler>
+void read_arpa(std::istream& infile, CountHandler&& count_handler,
+               NGramHandler&& ngram_handler)
+{
+    std::string buffer;
+
+    uint64_t order = 0;
+    // get to beginning of unigram data, observing the counts of each ngram type
+    while (std::getline(infile, buffer))
+    {
+        if (buffer.find("ngram ") == 0)
+        {
+            auto equal = buffer.find_first_of("=");
+            count_handler(order, std::stoul(buffer.substr(equal + 1)));
+            ++order;
+        }
+
+        if (buffer.find("\\1-grams:") == 0)
+            break;
+    }
+
+    order = 0;
+    while (std::getline(infile, buffer))
+    {
+        // if blank or end
+        if (buffer.empty() || (buffer[0] == '\\' && buffer[1] == 'e'))
+            continue;
+
+        // if start of new ngram data
+        if (buffer[0] == '\\')
+        {
+            ++order;
+            continue;
+        }
+
+        auto first_tab = buffer.find_first_of('\t');
+        float prob = std::stof(buffer.substr(0, first_tab));
+        auto second_tab = buffer.find_first_of('\t', first_tab + 1);
+        auto ngram = buffer.substr(first_tab + 1, second_tab - first_tab - 1);
+        float backoff = 0.0;
+        if (second_tab != std::string::npos)
+            backoff = std::stof(buffer.substr(second_tab + 1));
+
+        ngram_handler(order, ngram, prob, backoff);
+    }
+}
+}
+}
+#endif

--- a/include/meta/lm/read_arpa.h
+++ b/include/meta/lm/read_arpa.h
@@ -34,20 +34,29 @@ void read_arpa(std::istream& infile, CountHandler&& count_handler,
 {
     std::string buffer;
 
+    bool unigrams_found = false;
+    bool counts_found = false;
     uint64_t order = 0;
     // get to beginning of unigram data, observing the counts of each ngram type
     while (std::getline(infile, buffer))
     {
         if (buffer.find("ngram ") == 0)
         {
+            counts_found = true;
             auto equal = buffer.find_first_of("=");
             count_handler(order, std::stoul(buffer.substr(equal + 1)));
             ++order;
         }
 
         if (buffer.find("\\1-grams:") == 0)
+        {
+            unigrams_found = true;
             break;
+        }
     }
+
+    if (!unigrams_found || !counts_found)
+        throw std::runtime_error{"invalid .arpa format"};
 
     order = 0;
     while (std::getline(infile, buffer))

--- a/include/meta/lm/static_probe_map.h
+++ b/include/meta/lm/static_probe_map.h
@@ -71,6 +71,8 @@ class static_probe_map
         return find_hash(hashed);
     }
 
+    util::optional<lm_node> find(const std::vector<uint64_t>& ngram) const;
+
     /**
      * @param key The string key to insert (though only a uint64_t hash is
      * stored; if the hash already exists, an exception is thrown)

--- a/include/meta/lm/static_probe_map.h
+++ b/include/meta/lm/static_probe_map.h
@@ -49,29 +49,11 @@ class static_probe_map
     static_probe_map(static_probe_map&&) = default;
 
     /**
-     * @param key The string key to search for in this probe map
+     * @param key The key to search for in the map (vector of word ids)
      * @return an optional language model node containing the probability and
      * backoff value for the key
      */
-    util::optional<lm_node> find(const token_list& key) const;
-
-    /**
-     * Finds a key represented by a pair of iterators.
-     *
-     * @param begin The beginning of the list of token ids
-     * @param end The ending of the list of token ids
-     * @return an optional language model node containing the probability
-     * and backoff value for the key
-     */
-    template <class ForwardIterator>
-    util::optional<lm_node> find(ForwardIterator begin,
-                                 ForwardIterator end) const
-    {
-        auto hashed = hash(begin, end);
-        return find_hash(hashed);
-    }
-
-    util::optional<lm_node> find(const std::vector<uint64_t>& ngram) const;
+    util::optional<lm_node> find(const std::vector<uint64_t>& key) const;
 
     /**
      * @param key The string key to insert (though only a uint64_t hash is
@@ -83,24 +65,9 @@ class static_probe_map
 
   private:
     /**
-     * Helper function to create hasher and hash token list
+     * Helper function to create hasher and hash a list of word ids
      */
-    uint64_t hash(const token_list& tokens) const;
-
-    /**
-     * Helper function to create hasher and hash token list parameterized
-     * as a pair of iterators
-     */
-    template <class ForwardIterator>
-    uint64_t hash(ForwardIterator begin, ForwardIterator end) const
-    {
-        hashing::murmur_hash<> hasher{seed_};
-        auto dist = std::distance(begin, end);
-        for (; begin != end; ++begin)
-            hash_append(hasher, *begin);
-        hash_append(hasher, dist);
-        return static_cast<std::size_t>(hasher);
-    }
+    uint64_t hash(const std::vector<uint64_t>& tokens) const;
 
     /// Helper function to find a node given the hash value
     util::optional<lm_node> find_hash(uint64_t hashed) const;

--- a/include/meta/lm/static_probe_map.h
+++ b/include/meta/lm/static_probe_map.h
@@ -53,7 +53,7 @@ class static_probe_map
      * @return an optional language model node containing the probability and
      * backoff value for the key
      */
-    util::optional<lm_node> find(const std::vector<uint64_t>& key) const;
+    util::optional<lm_node> find(const std::vector<term_id>& key) const;
 
     /**
      * @param key The string key to insert (though only a uint64_t hash is
@@ -67,7 +67,7 @@ class static_probe_map
     /**
      * Helper function to create hasher and hash a list of word ids
      */
-    uint64_t hash(const std::vector<uint64_t>& tokens) const;
+    uint64_t hash(const std::vector<term_id>& tokens) const;
 
     /// Helper function to find a node given the hash value
     util::optional<lm_node> find_hash(uint64_t hashed) const;

--- a/include/meta/succinct/bit_vector.h
+++ b/include/meta/succinct/bit_vector.h
@@ -31,8 +31,10 @@ class packed_bits
   public:
     packed_bits(uint64_t word, uint8_t len) : word_{word}, len_{len}
     {
+#if DEBUG
         if (META_UNLIKELY(len > 64))
             throw std::invalid_argument{"bit length longer than word"};
+#endif
 
         auto mask = len_ == 64 ? static_cast<uint64_t>(-1) : (1ull << len_) - 1;
         word_ &= mask;

--- a/include/meta/succinct/compressed_vector.h
+++ b/include/meta/succinct/compressed_vector.h
@@ -60,17 +60,22 @@ void make_compressed_vector(const std::string& prefix, ForwardIterator begin,
         ++num_elems;
     }
 
-    filesystem::make_directory(prefix + "/sarray");
-    sarray_builder s_builder{prefix + "/sarray", num_elems + 1, num_bits};
-    s_builder(bv_builder.total_bits());
-    for (auto it = begin; it != end; ++it)
     {
-        uint64_t word = *it;
-        uint64_t len = (word) ? broadword::msb(word) : 1;
-        bv_builder.write_bits({word, static_cast<uint8_t>(len)});
-
+        filesystem::make_directory(prefix + "/sarray");
+        sarray_builder s_builder{prefix + "/sarray", num_elems + 1, num_bits};
         s_builder(bv_builder.total_bits());
+        for (auto it = begin; it != end; ++it)
+        {
+            uint64_t word = *it;
+            uint64_t len = (word) ? broadword::msb(word) : 1;
+            bv_builder.write_bits({word, static_cast<uint8_t>(len)});
+
+            s_builder(bv_builder.total_bits());
+        }
     }
+
+    sarray select{prefix + "/sarray"};
+    sarray_select{prefix + "/sarray", select};
 }
 }
 }

--- a/include/meta/succinct/darray.h
+++ b/include/meta/succinct/darray.h
@@ -304,8 +304,10 @@ class darray
         {
             using namespace darray_detail;
 
+#if DEBUG
             if (META_UNLIKELY(i >= num_ones))
                 throw std::out_of_range{"index out of range in select query"};
+#endif
 
             auto block_idx = i / ones_per_block;
             if (blocks[block_idx] < 0)

--- a/include/meta/succinct/darray.h
+++ b/include/meta/succinct/darray.h
@@ -10,7 +10,6 @@
 #ifndef META_SUCCINCT_DARRAY_H_
 #define META_SUCCINCT_DARRAY_H_
 
-#include <iostream>
 #include <fstream>
 #include "meta/io/binary.h"
 #include "meta/io/filesystem.h"
@@ -213,6 +212,7 @@ class darray_builder
             {
                 auto offset = static_cast<uint16_t>(current_block[i]
                                                     - current_block[0]);
+                assert(i == 0 || offset > 0);
                 io::write_binary(sub_blocks, offset);
             }
         }
@@ -291,7 +291,7 @@ class darray
         {
             using namespace darray_detail;
 
-            if (META_UNLIKELY(i > num_ones))
+            if (META_UNLIKELY(i >= num_ones))
                 throw std::out_of_range{"index out of range in select query"};
 
             auto block_idx = i / ones_per_block;
@@ -323,7 +323,7 @@ class darray
             {
                 auto popcount = broadword::popcount(word);
                 if (one_count < popcount)
-                  break;
+                    break;
                 one_count -= popcount;
                 word = WordReader{}(words[++word_idx]);
             }

--- a/include/meta/util/algorithm.h
+++ b/include/meta/util/algorithm.h
@@ -47,7 +47,7 @@ template <class InputIt, class Delims, class BinOp>
 void for_each_token(InputIt first, InputIt last, const Delims& delims,
                     BinOp binary_op)
 {
-    for_each_token(first, last, std::cbegin(delims), std::cend(delims),
+    for_each_token(first, last, std::begin(delims), std::end(delims),
                    binary_op);
 }
 }

--- a/include/meta/util/algorithm.h
+++ b/include/meta/util/algorithm.h
@@ -1,0 +1,55 @@
+/**
+ * @file algorithm.h
+ * @author Chase Geigle
+ *
+ * All files in META are dual-licensed under the MIT and NCSA licenses. For more
+ * details, consult the file LICENSE.mit and LICENSE.ncsa in the root of the
+ * project.
+ */
+
+#ifndef META_UTIL_ALGORITHM_H_
+#define META_UTIL_ALGORITHM_H_
+
+#include <algorithm>
+
+namespace meta
+{
+namespace util
+{
+
+/**
+ * Applys the binary operator to each token in the range [first, last) that
+ * is delimited a token in [s_first, s_last).
+ *
+ * @see http://tristanbrindle.com/posts/a-quicker-study-on-tokenising/
+ */
+template <class InputIt, class ForwardIt, class BinOp>
+void for_each_token(InputIt first, InputIt last, ForwardIt s_first,
+                    ForwardIt s_last, BinOp binary_op)
+{
+    while (first != last)
+    {
+        const auto pos = std::find_first_of(first, last, s_first, s_last);
+        binary_op(first, pos);
+        if (pos == last)
+            break;
+        first = std::next(pos);
+    }
+}
+
+/**
+ * Applys the binary operator to each token in the range [first, last) that
+ * is delimited a token in delims.
+ *
+ * @see http://tristanbrindle.com/posts/a-quicker-study-on-tokenising/
+ */
+template <class InputIt, class Delims, class BinOp>
+void for_each_token(InputIt first, InputIt last, const Delims& delims,
+                    BinOp binary_op)
+{
+    for_each_token(first, last, std::cbegin(delims), std::cend(delims),
+                   binary_op);
+}
+}
+}
+#endif

--- a/include/meta/util/optional.tcc
+++ b/include/meta/util/optional.tcc
@@ -66,7 +66,7 @@ optional<T>::optional(optional&& opt)
     : initialized_{opt.initialized_}, storage_{trivial_init}
 {
     if (opt.initialized_)
-        new (dataptr()) T{std::move(opt.storage_.value_)};
+        new (dataptr()) T(std::move(opt.storage_.value_));
 }
 
 template <class T>

--- a/include/meta/util/optional.tcc
+++ b/include/meta/util/optional.tcc
@@ -20,7 +20,7 @@ optional_storage<T>::optional_storage(trivial_init_t)
 template <class T>
 template <class... Args>
 optional_storage<T>::optional_storage(Args&&... args)
-    : value_{std::forward<Args>(args)...}
+    : value_(std::forward<Args>(args)...)
 {
     /* nothing */
 }
@@ -66,7 +66,7 @@ optional<T>::optional(optional&& opt)
     : initialized_{opt.initialized_}, storage_{trivial_init}
 {
     if (opt.initialized_)
-        new (dataptr()) T{std::move(*opt)};
+        new (dataptr()) T{std::move(opt.storage_.value_)};
 }
 
 template <class T>

--- a/include/meta/util/string_view.h
+++ b/include/meta/util/string_view.h
@@ -407,16 +407,12 @@ class basic_string_view
         if (pos >= size())
             return npos;
 
-        auto it
-            = std::find_if(begin(), end(), [&](const_reference c)
-                           {
-                               return std::find_if(s.begin(), s.end(),
-                                                   [&](const_reference sc)
-                                                   {
-                                                       return Traits::eq(c, sc);
-                                                   })
-                                      == s.end();
-                           });
+        auto it = std::find_if(begin(), end(), [&](const_reference c) {
+            return std::find_if(
+                       s.begin(), s.end(),
+                       [&](const_reference sc) { return Traits::eq(c, sc); })
+                   == s.end();
+        });
         if (it == end())
             return npos;
         return static_cast<size_type>(std::distance(begin(), it));
@@ -447,16 +443,12 @@ class basic_string_view
             return npos;
 
         auto diff = size() - std::min(size(), pos);
-        auto it
-            = std::find_if(rbegin() + diff, rend(), [&](const_reference c)
-                           {
-                               return std::find_if(s.begin(), s.end(),
-                                                   [&](const_reference sc)
-                                                   {
-                                                       return Traits::eq(c, sc);
-                                                   })
-                                      == s.end();
-                           });
+        auto it = std::find_if(rbegin() + diff, rend(), [&](const_reference c) {
+            return std::find_if(
+                       s.begin(), s.end(),
+                       [&](const_reference sc) { return Traits::eq(c, sc); })
+                   == s.end();
+        });
         if (it == rend())
             return npos;
         return size() - 1 - std::distance(rbegin(), it);
@@ -648,6 +640,17 @@ struct hash<meta::util::basic_string_view<Char, Traits>>
 
 namespace meta
 {
+
+namespace util
+{
+inline string_view make_string_view(std::string::const_iterator begin,
+                                    std::string::const_iterator end)
+{
+    return string_view{&*begin,
+                       static_cast<string_view::size_type>(end - begin)};
+}
+}
+
 namespace hashing
 {
 template <class HashAlgorithm, class Char, class Traits>

--- a/src/embeddings/tools/embedding_coocur.cpp
+++ b/src/embeddings/tools/embedding_coocur.cpp
@@ -113,7 +113,7 @@ class coocur_buffer
             = util::multiway_merge(chunks.begin(), chunks.end(),
                                    [&](embeddings::coocur_record&& record)
                                    {
-                                       record.write(output);
+                                       io::packed::write(output, record);
                                    });
         chunks.clear();
 

--- a/src/embeddings/tools/glove.cpp
+++ b/src/embeddings/tools/glove.cpp
@@ -69,7 +69,7 @@ std::size_t shuffle_partition(const std::string& prefix, std::size_t max_ram,
                 total_records += i;
                 chunk_sizes.push_back(i);
                 for (std::size_t j = 0; j < i; ++j)
-                    records[j].write(output);
+                    io::packed::write(output, records[j]);
             }
         });
 
@@ -125,7 +125,7 @@ std::size_t shuffle_partition(const std::string& prefix, std::size_t max_ram,
             for (std::size_t j = 0; j < i; ++j)
             {
                 auto idx = random::bounded_rand(engine, outputs.size());
-                records[j].write(outputs[idx]);
+                io::packed::write(outputs[idx], records[j]);
             }
         }
     }

--- a/src/lm/CMakeLists.txt
+++ b/src/lm/CMakeLists.txt
@@ -6,7 +6,9 @@ add_subdirectory(analyzers)
 add_library(meta-language-model language_model.cpp
                                 token_list.cpp
                                 diff.cpp
+                                mph_language_model.cpp
                                 static_probe_map.cpp
                                 sentence.cpp)
 target_link_libraries(meta-language-model meta-corpus
-                                          meta-analyzers)
+                                          meta-analyzers
+                                          meta-succinct)

--- a/src/lm/language_model.cpp
+++ b/src/lm/language_model.cpp
@@ -209,6 +209,11 @@ uint64_t language_model::index(const std::string& token) const
     return it != vocabulary_.end() ? it->second : unk_id_;
 }
 
+uint64_t language_model::unk() const
+{
+    return unk_id_;
+}
+
 float language_model::score(const lm_state& in_state, uint64_t token,
                             lm_state& out_state) const
 {

--- a/src/lm/language_model.cpp
+++ b/src/lm/language_model.cpp
@@ -217,6 +217,9 @@ uint64_t language_model::unk() const
 float language_model::score(const lm_state& in_state, uint64_t token,
                             lm_state& out_state) const
 {
+    out_state = in_state;
+    out_state.previous.push_back(token);
+
     // (1) Find the longest matching ngram
     if (out_state.previous.size() == N_)
     {

--- a/src/lm/language_model.cpp
+++ b/src/lm/language_model.cpp
@@ -58,7 +58,7 @@ language_model::language_model(const cpptoml::table& config)
     // cache this value
     auto unk = vocabulary_.at("<unk>");
     unk_id_ = unk;
-    unk_node_ = *lm_[0].find(&unk, &unk + 1);
+    unk_node_ = *lm_[0].find({unk_id_});
 }
 
 void language_model::read_arpa_format(const std::string& arpa_file)
@@ -201,7 +201,7 @@ float language_model::score(const lm_state& in_state, uint64_t token,
 
     if (out_state.previous.size() == 1)
     {
-        auto uni_node = lm_[0].find(&token, &token + 1).value_or(unk_node_);
+        auto uni_node = lm_[0].find(out_state.previous).value_or(unk_node_);
         res = uni_node.prob;
     }
 

--- a/src/lm/language_model.cpp
+++ b/src/lm/language_model.cpp
@@ -159,18 +159,18 @@ float language_model::perplexity_per_word(const sentence& tokens) const
     return perplexity(tokens) / tokens.size();
 }
 
-uint64_t language_model::index(const std::string& token) const
+term_id language_model::index(const std::string& token) const
 {
     auto it = vocabulary_.find(token);
     return it != vocabulary_.end() ? it->second : unk_id_;
 }
 
-uint64_t language_model::unk() const
+term_id language_model::unk() const
 {
     return unk_id_;
 }
 
-float language_model::score(const lm_state& in_state, uint64_t token,
+float language_model::score(const lm_state& in_state, term_id token,
                             lm_state& out_state) const
 {
     out_state = in_state;

--- a/src/lm/mph_language_model.cpp
+++ b/src/lm/mph_language_model.cpp
@@ -1,0 +1,271 @@
+/**
+ * @file mph_language_model.cpp
+ * @author Chase Geigle
+ *
+ * All files in META are dual-licensed under the MIT and NCSA licenses. For more
+ * details, consult the file LICENSE.mit and LICENSE.ncsa in the root of the
+ * project.
+ */
+
+#include <cassert>
+
+#include "meta/io/filesystem.h"
+#include "meta/lm/mph_language_model.h"
+#include "meta/lm/ngram_map.h"
+#include "meta/util/algorithm.h"
+#include "meta/util/shim.h"
+#include "meta/util/time.h"
+
+namespace meta
+{
+namespace lm
+{
+
+namespace
+{
+template <class NGramHandler>
+void read_from_arpa(const std::string& filename, NGramHandler&& ngram_handler)
+{
+    std::ifstream infile{filename};
+    std::string buffer;
+
+    // get to beginning of unigram data, observing the counts of each ngram type
+    while (std::getline(infile, buffer))
+    {
+        if (buffer.find("ngram ") == 0)
+        {
+            auto equal = buffer.find_first_of("=");
+            ngram_handler.count(std::stoul(buffer.substr(equal + 1)));
+        }
+
+        if (buffer.find("\\1-grams:") == 0)
+            break;
+    }
+
+    uint64_t order = 0;
+    while (std::getline(infile, buffer))
+    {
+        // if blank or end
+        if (buffer.empty() || (buffer[0] == '\\' && buffer[1] == 'e'))
+            continue;
+
+        // if start of new ngram data
+        if (buffer[0] == '\\')
+        {
+            ++order;
+            continue;
+        }
+
+        auto first_tab = buffer.find_first_of('\t');
+        float prob = std::stof(buffer.substr(0, first_tab));
+        auto second_tab = buffer.find_first_of('\t', first_tab + 1);
+        auto ngram = buffer.substr(first_tab + 1, second_tab - first_tab - 1);
+        float backoff = 0.0;
+        if (second_tab != std::string::npos)
+            backoff = std::stof(buffer.substr(second_tab + 1));
+
+        ngram_handler(order, ngram, prob, backoff);
+    }
+}
+
+class ngram_handler
+{
+  public:
+    using unigram_builder_type = ngram_map_builder<std::string>;
+    using middle_builder_type = ngram_map_builder<std::vector<uint64_t>>;
+    using last_builder_type = ngram_map_builder<std::vector<uint64_t>, float>;
+
+    ngram_handler(const std::string& prefix) : prefix_{prefix}
+    {
+        // nothing
+    }
+
+    void count(uint64_t ngram_count)
+    {
+        counts_.emplace_back(ngram_count);
+        LOG(info) << counts_.size() << "-gram count: " << ngram_count << ENDLG;
+        if (counts_.size() == 1)
+        {
+            unigram_builder_type::options_type options;
+            options.prefix = prefix_ + "/0/";
+            options.num_keys = ngram_count;
+
+            filesystem::make_directory(options.prefix);
+
+            unigram_builder_ = make_unique<unigram_builder_type>(options);
+        }
+    }
+
+    void operator()(uint64_t order, const std::string& ngram, float prob,
+                    float backoff)
+    {
+        if (order > order_)
+        {
+            finish_order();
+            order_ = order;
+        }
+
+        ++observed_;
+        if (observed_ > counts_[order])
+            throw std::runtime_error{"too many " + std::to_string(order + 1)
+                                     + "-grams"};
+
+        if (order_ == 0)
+        {
+            assert(unigram_builder_);
+            prob_backoff<> value;
+            value.prob = prob;
+            value.backoff = backoff;
+            (*unigram_builder_)(ngram, value);
+        }
+        else
+        {
+            assert(middle_builder_ || last_builder_);
+            assert(unigrams_);
+
+            std::vector<uint64_t> ids;
+            ids.reserve(order);
+
+            util::for_each_token(
+                ngram.begin(), ngram.end(), " ",
+                [&](std::string::const_iterator first,
+                    std::string::const_iterator last)
+                {
+                    if (first != last)
+                    {
+                        std::string unigram{first, last};
+                        auto id = unigrams_->index({first, last});
+                        if (!id)
+                            throw std::runtime_error{
+                                "ngram contains unknown unigram " + unigram};
+                        ids.push_back(*id);
+                    }
+                });
+
+            assert(ids.size() == order + 1);
+
+            prob_backoff<> value;
+            value.prob = prob;
+            value.backoff = backoff;
+
+            if (order_ != counts_.size() - 1)
+                (*middle_builder_)(ids, value);
+            else
+                (*last_builder_)(ids, prob);
+        }
+    }
+
+    uint64_t order() const
+    {
+        return order_;
+    }
+
+    void finish_order()
+    {
+        LOG(info) << "Finalizing " << order_ + 1 << "-grams (" << observed_
+                  << ")" << ENDLG;
+        observed_ = 0;
+        // unigrams
+        if (order_ == 0)
+        {
+            assert(unigram_builder_);
+            unigram_builder_->write();
+            unigram_builder_ = nullptr;
+
+            // now that the unigrams are written, we're going to load their
+            // ngram_map to use as a vocabulary lookup
+            unigrams_ = make_unique<ngram_map<std::string>>(prefix_ + "/0");
+            LOG(info) << "Loaded unigram map" << ENDLG;
+
+            middle_builder_type::options_type options;
+            options.prefix = prefix_ + "/" + std::to_string(order_ + 1);
+            options.num_keys = counts_[order_ + 1];
+
+            filesystem::make_directory(options.prefix);
+
+            middle_builder_ = make_unique<middle_builder_type>(options);
+        }
+        // middle
+        else if (order_ < counts_.size() - 1)
+        {
+            assert(middle_builder_);
+            middle_builder_->write();
+
+            // set up the next middle builder
+            if (order_ + 1 < counts_.size() - 1)
+            {
+                middle_builder_type::options_type options;
+                options.prefix = prefix_ + "/" + std::to_string(order_ + 1);
+                options.num_keys = counts_[order_ + 1];
+
+                filesystem::make_directory(options.prefix);
+
+                middle_builder_ = make_unique<middle_builder_type>(options);
+            }
+            // here come the final ngrams
+            else
+            {
+                middle_builder_ = nullptr;
+
+                last_builder_type::options_type options;
+                options.prefix = prefix_ + "/" + std::to_string(order_ + 1);
+                options.num_keys = counts_[order_ + 1];
+
+                filesystem::make_directory(options.prefix);
+
+                last_builder_ = make_unique<last_builder_type>(options);
+            }
+        }
+        // last
+        else
+        {
+            assert(last_builder_);
+            last_builder_->write();
+            last_builder_ = nullptr;
+        }
+    }
+
+  private:
+    std::string prefix_;
+    uint64_t order_ = 0;
+    uint64_t observed_ = 0;
+    std::vector<uint64_t> counts_;
+    std::unique_ptr<unigram_builder_type> unigram_builder_;
+    std::unique_ptr<ngram_map<std::string>> unigrams_;
+    std::unique_ptr<middle_builder_type> middle_builder_;
+    std::unique_ptr<last_builder_type> last_builder_;
+};
+
+uint64_t build_from_arpa(const std::string& arpa_file,
+                         const std::string& prefix)
+{
+    filesystem::remove_all(prefix);
+    filesystem::make_directory(prefix);
+    ngram_handler handler{prefix};
+    read_from_arpa(arpa_file, handler);
+
+    // finish off the n-grams
+    handler.finish_order();
+
+    return handler.order();
+}
+}
+
+mph_language_model::mph_language_model(const cpptoml::table& config)
+{
+    auto table = config.get_table("mph-language-model");
+    auto arpa_file = table->get_as<std::string>("arpa-file");
+    auto prefix = table->get_as<std::string>("binary-file-prefix");
+
+    LOG(info) << "Building language model from .arpa file: " << *arpa_file
+              << ENDLG;
+
+    uint64_t order;
+    auto time = common::time([&]()
+                             {
+                                 order = build_from_arpa(*arpa_file, *prefix);
+                             });
+    LOG(info) << "Done. (" << time.count() << "ms)" << ENDLG;
+}
+}
+}

--- a/src/lm/mph_language_model.cpp
+++ b/src/lm/mph_language_model.cpp
@@ -230,8 +230,8 @@ struct mph_language_model::impl
     using middle_map_type = ngram_map<std::vector<uint64_t>>;
     using last_map_type = ngram_map<std::vector<uint64_t>, float>;
 
-    impl(const std::string& prefix, uint64_t o)
-        : order{o},
+    impl(const std::string& prefix, uint64_t ord)
+        : order{ord},
           unigrams{prefix + "/0"},
           last{prefix + "/" + std::to_string(order)}
     {
@@ -278,10 +278,10 @@ mph_language_model::mph_language_model(const cpptoml::table& config)
 
     if (!order)
     {
-        for (uint64_t o = 0; filesystem::file_exists(
-                 *prefix + "/" + std::to_string(o) + "/values.bin");
-             ++o)
-            order = o;
+        for (uint64_t ord = 0; filesystem::file_exists(
+                 *prefix + "/" + std::to_string(ord) + "/values.bin");
+             ++ord)
+            order = ord;
     }
 
     impl_ = make_unique<impl>(*prefix, *order);

--- a/src/lm/mph_language_model.cpp
+++ b/src/lm/mph_language_model.cpp
@@ -291,7 +291,7 @@ struct mph_language_model::impl
     }
 
     uint64_t order;
-    hashing::index_and_value<prob_backoff<>> unk;
+    hashing::indexed_value<prob_backoff<>> unk;
     unigram_map_type unigrams;
     std::vector<std::unique_ptr<middle_map_type>> middle_vec;
     last_map_type last;

--- a/src/lm/static_probe_map.cpp
+++ b/src/lm/static_probe_map.cpp
@@ -41,8 +41,15 @@ void static_probe_map::insert(const token_list& key, float prob, float backoff)
 
 util::optional<lm_node> static_probe_map::find(const token_list& key) const
 {
-    auto hashed = hash(key);
-    return find_hash(hashed);
+    return find(key.tokens());
+}
+
+util::optional<lm_node>
+static_probe_map::find(const std::vector<uint64_t>& ngram) const
+{
+    hashing::murmur_hash<> hasher{seed_};
+    hash_append(hasher, ngram);
+    return find_hash(static_cast<std::size_t>(hasher));
 }
 
 util::optional<lm_node> static_probe_map::find_hash(uint64_t hashed) const

--- a/src/lm/static_probe_map.cpp
+++ b/src/lm/static_probe_map.cpp
@@ -19,7 +19,7 @@ static_probe_map::static_probe_map(const std::string& filename,
 
 void static_probe_map::insert(const token_list& key, float prob, float backoff)
 {
-    auto hashed = hash(key);
+    auto hashed = hash(key.tokens());
     auto idx = (hashed % (table_.size() / 2)) * 2;
 
     while (true)
@@ -39,17 +39,10 @@ void static_probe_map::insert(const token_list& key, float prob, float backoff)
     }
 }
 
-util::optional<lm_node> static_probe_map::find(const token_list& key) const
-{
-    return find(key.tokens());
-}
-
 util::optional<lm_node>
 static_probe_map::find(const std::vector<uint64_t>& ngram) const
 {
-    hashing::murmur_hash<> hasher{seed_};
-    hash_append(hasher, ngram);
-    return find_hash(static_cast<std::size_t>(hasher));
+    return find_hash(hash(ngram));
 }
 
 util::optional<lm_node> static_probe_map::find_hash(uint64_t hashed) const
@@ -68,9 +61,11 @@ util::optional<lm_node> static_probe_map::find_hash(uint64_t hashed) const
     }
 }
 
-uint64_t static_probe_map::hash(const token_list& tokens) const
+uint64_t static_probe_map::hash(const std::vector<uint64_t>& tokens) const
 {
-    return hash(tokens.tokens().begin(), tokens.tokens().end());
+    hashing::murmur_hash<> hasher{seed_};
+    hash_append(hasher, tokens);
+    return static_cast<std::size_t>(hasher);
 }
 }
 }

--- a/src/lm/static_probe_map.cpp
+++ b/src/lm/static_probe_map.cpp
@@ -40,7 +40,7 @@ void static_probe_map::insert(const token_list& key, float prob, float backoff)
 }
 
 util::optional<lm_node>
-static_probe_map::find(const std::vector<uint64_t>& ngram) const
+static_probe_map::find(const std::vector<term_id>& ngram) const
 {
     return find_hash(hash(ngram));
 }
@@ -61,7 +61,7 @@ util::optional<lm_node> static_probe_map::find_hash(uint64_t hashed) const
     }
 }
 
-uint64_t static_probe_map::hash(const std::vector<uint64_t>& tokens) const
+uint64_t static_probe_map::hash(const std::vector<term_id>& tokens) const
 {
     hashing::murmur_hash<> hasher{seed_};
     hash_append(hasher, tokens);

--- a/src/lm/tools/CMakeLists.txt
+++ b/src/lm/tools/CMakeLists.txt
@@ -6,3 +6,6 @@ target_link_libraries(sentence-likelihood meta-language-model meta-index)
 
 add_executable(build-mph-lm build_mph_lm.cpp)
 target_link_libraries(build-mph-lm meta-language-model meta-io)
+
+add_executable(query-mph-lm query_mph_lm.cpp)
+target_link_libraries(query-mph-lm meta-language-model meta-io)

--- a/src/lm/tools/CMakeLists.txt
+++ b/src/lm/tools/CMakeLists.txt
@@ -7,5 +7,5 @@ target_link_libraries(sentence-likelihood meta-language-model meta-index)
 add_executable(build-mph-lm build_mph_lm.cpp)
 target_link_libraries(build-mph-lm meta-language-model meta-io)
 
-add_executable(query-mph-lm query_mph_lm.cpp)
-target_link_libraries(query-mph-lm meta-language-model meta-io)
+add_executable(query-lm query_lm.cpp)
+target_link_libraries(query-lm meta-language-model meta-io)

--- a/src/lm/tools/CMakeLists.txt
+++ b/src/lm/tools/CMakeLists.txt
@@ -3,3 +3,6 @@ target_link_libraries(diff-test meta-language-model meta-index)
 
 add_executable(sentence-likelihood sentence_likelihood.cpp)
 target_link_libraries(sentence-likelihood meta-language-model meta-index)
+
+add_executable(build-mph-lm build_mph_lm.cpp)
+target_link_libraries(build-mph-lm meta-language-model meta-io)

--- a/src/lm/tools/build_mph_lm.cpp
+++ b/src/lm/tools/build_mph_lm.cpp
@@ -1,0 +1,36 @@
+/**
+ * @file build_mph_lm.cpp
+ * @author Chase Geigle
+ */
+
+#include <iostream>
+
+#include "meta/lm/mph_language_model.h"
+#include "meta/logging/logger.h"
+
+int main(int argc, char** argv)
+{
+    using namespace meta;
+
+    if (argc != 2)
+    {
+        std::cerr << "Usage: " << argv[0] << " config.toml" << std::endl;
+        return 1;
+    }
+
+    logging::set_cerr_logging();
+
+    auto config = cpptoml::parse_file(argv[1]);
+
+    try
+    {
+        lm::mph_language_model model{*config};
+    }
+    catch (const std::exception& ex)
+    {
+        std::cerr << "hash seed: " << hashing::detail::get_process_seed()
+                  << std::endl;
+        throw;
+    }
+    return 0;
+}

--- a/src/lm/tools/query_lm.cpp
+++ b/src/lm/tools/query_lm.cpp
@@ -31,7 +31,6 @@ void query_lm(const LanguageModel& model, bool verbose = false)
         util::for_each_token(
             line.begin(), line.end(), " ",
             [&](std::string::iterator begin, std::string::iterator end) {
-                //auto tok = util::make_string_view(begin, end);
                 std::string tok{begin, end};
                 auto idx = model.index(tok);
                 auto score = model.score(state, idx, state_next);

--- a/src/lm/tools/query_mph_lm.cpp
+++ b/src/lm/tools/query_mph_lm.cpp
@@ -1,0 +1,79 @@
+/**
+ * @file query_mph_lm.cpp
+ * @author Chase Geigle
+ */
+
+#include <iostream>
+
+#include "meta/analyzers/tokenizers/icu_tokenizer.h"
+#include "meta/analyzers/tokenizers/whitespace_tokenizer.h"
+#include "meta/lm/mph_language_model.h"
+#include "meta/logging/logger.h"
+#include "meta/util/algorithm.h"
+
+int main(int argc, char** argv)
+{
+    using namespace meta;
+
+    if (argc < 2)
+    {
+        std::cerr << "Usage: " << argv[0] << " config.toml" << std::endl;
+        return 1;
+    }
+
+    logging::set_cerr_logging();
+
+    auto config = cpptoml::parse_file(argv[1]);
+    lm::mph_language_model model{*config};
+
+    // record similar statistics to KenLM
+    double total = 0.0;
+    double total_oov_only = 0.0;
+    uint64_t oov = 0;
+    uint64_t tokens = 0;
+
+    bool verbose = argc > 2;
+    std::string line;
+    while (std::getline(std::cin, line))
+    {
+        lm::lm_state state{{model.index("<s>")}};
+        lm::lm_state state_next;
+
+        util::for_each_token(
+            line.begin(), line.end(), " ",
+            [&](std::string::iterator begin, std::string::iterator end) {
+                auto tok = util::make_string_view(begin, end);
+                auto idx = model.index(tok);
+                auto score = model.score(state, idx, state_next);
+                if (verbose)
+                    std::cout << tok << "=" << idx << " "
+                              << state_next.previous.size() << " " << score
+                              << " ";
+                if (idx == model.unk())
+                {
+                    total_oov_only += score;
+                    ++oov;
+                }
+                total += score;
+                state = state_next;
+                ++tokens;
+            });
+
+        auto idx = model.index("</s>");
+        auto score = model.score(state, idx, state_next);
+        if (verbose)
+            std::cout << "</s>=" << idx << " " << state_next.previous.size()
+                      << " " << score << "\n";
+        total += score;
+        ++tokens;
+    }
+
+    std::cout << "Perplexity including OOVs:\t"
+              << std::pow(10, -total / static_cast<double>(tokens))
+              << "\nPerplexity excluding OOVs:\t"
+              << std::pow(10, -(total - total_oov_only)
+                                  / static_cast<double>(tokens - oov))
+              << "\nOOVs:\t" << oov << "\nTokens:\t" << tokens << std::endl;
+
+    return 0;
+}

--- a/src/succinct/bit_vector.cpp
+++ b/src/succinct/bit_vector.cpp
@@ -7,8 +7,8 @@
  * project.
  */
 
-#include "meta/math/integer.h"
 #include "meta/succinct/bit_vector.h"
+#include "meta/math/integer.h"
 #include "meta/util/likely.h"
 
 namespace meta
@@ -36,11 +36,13 @@ bool bit_vector_view::operator[](uint64_t bit_idx) const
 
 uint64_t bit_vector_view::extract(uint64_t bit_idx, uint8_t len) const
 {
+#if DEBUG
     if (META_UNLIKELY(len > 64))
         throw std::out_of_range{"bit length longer than word"};
 
     if (META_UNLIKELY(bit_idx > size()))
         throw std::out_of_range{"bit index larger than bit count"};
+#endif
 
     auto word_pos = bit_idx / 64;
     auto bit_pos = bit_idx % 64;

--- a/src/succinct/bit_vector.cpp
+++ b/src/succinct/bit_vector.cpp
@@ -37,7 +37,10 @@ bool bit_vector_view::operator[](uint64_t bit_idx) const
 uint64_t bit_vector_view::extract(uint64_t bit_idx, uint8_t len) const
 {
     if (META_UNLIKELY(len > 64))
-        throw std::invalid_argument{"bit length longer than word"};
+        throw std::out_of_range{"bit length longer than word"};
+
+    if (META_UNLIKELY(bit_idx > size()))
+        throw std::out_of_range{"bit index larger than bit count"};
 
     auto word_pos = bit_idx / 64;
     auto bit_pos = bit_idx % 64;

--- a/src/succinct/sarray.cpp
+++ b/src/succinct/sarray.cpp
@@ -112,10 +112,14 @@ sarray_rank::sarray_rank(const std::string& prefix, const sarray& sarr)
 uint64_t sarray_rank::rank(uint64_t i) const
 {
     auto num_low_bits = sarray_->num_low_bits();
-    uint64_t high_query
-        = std::min(i >> num_low_bits, high_bit_zeroes_.num_positions());
+    auto high_query = i >> num_low_bits;
 
-    uint64_t high_pos = high_bit_zeroes_.select(high_query);
+    // make sure we don't query off the end of the zero index
+    if (high_query >= high_bit_zeroes_.num_positions())
+        return size();
+
+    auto high_pos = high_bit_zeroes_.select(high_query);
+
     uint64_t rank = high_pos - high_query;
 
     auto high_bvv = sarray_->high_bits();


### PR DESCRIPTION
This PR contains code that coexists with the existing language model that implements a minimal perfect hashing-based language model using the perfect hashing framework added in a previous merge.

The LM's query interface is different from the existing language model and more closely models the interface provided by KenLM. It produces (on my limited test data) identical perplexity results, but is not particularly fast.

A few additional minor things are included:

* `std::vector<T>` can now be hashed using the `hash_append` framework.

* `std::vector<T>` can be read/written using `io::packed`.

* `io::packed` has been refactored to make adding packed reading/writing routines for user-defined types easier, and is similar in spirit to `hash_append`.

  Users can provide `packed_read` and `packed_write` functions in the same namespace scope as their type, and `io::packed::read` and `io::packed::write` will find them via ADL.

* All `chunk_iterators` for `util::multiway_merge` have been consolidated into a single template class. This reduces quite a bit of code duplication across all of the disk-based merge algorithms we have.