### PR TITLE
Embedding analyzer

### DIFF
--- a/include/meta/embeddings/analyzers/embedding_analyzer.h
+++ b/include/meta/embeddings/analyzers/embedding_analyzer.h
@@ -29,12 +29,8 @@ namespace analyzers
  * [[analyzers]]
  * method = "embedding" # this analyzer
  * filter = # use same filter type that embeddings were learned with
- *
- * [embeddings]
- * prefix = "path/to/learned/embeddings"
+ * prefix = "path/to/embedding/model/"
  * ~~~
- *
- * Optional config parameters: none.
  */
 class embedding_analyzer : public util::clonable<analyzer, embedding_analyzer>
 {
@@ -64,6 +60,12 @@ class embedding_analyzer : public util::clonable<analyzer, embedding_analyzer>
 
     /// Learned word embeddings
     std::shared_ptr<embeddings::word_embeddings> embeddings_;
+
+    /// Path to the embedding model files
+    std::string prefix_;
+
+    /// Storage for the aggregated word embeddings per document
+    std::vector<double> features_;
 };
 
 /**

--- a/include/meta/embeddings/analyzers/embedding_analyzer.h
+++ b/include/meta/embeddings/analyzers/embedding_analyzer.h
@@ -21,7 +21,9 @@ namespace analyzers
 {
 
 /**
- * Analyzes documents by averaging word embeddings for each token.
+ * Analyzes documents by averaging word embeddings for each token. This analyzer
+ * should only be used with forward_index since it stores double features
+ * values.
  *
  * Required config parameters:
  * ~~~toml

--- a/include/meta/embeddings/analyzers/embedding_analyzer.h
+++ b/include/meta/embeddings/analyzers/embedding_analyzer.h
@@ -22,8 +22,7 @@ namespace analyzers
 
 /**
  * Analyzes documents by averaging word embeddings for each token. This analyzer
- * should only be used with forward_index since it stores double features
- * values.
+ * should only be used with forward_index since it stores double feature values.
  *
  * Required config parameters:
  * ~~~toml

--- a/include/meta/embeddings/analyzers/embedding_analyzer.h
+++ b/include/meta/embeddings/analyzers/embedding_analyzer.h
@@ -1,0 +1,84 @@
+/**
+ * @file embedding_analyzer.h
+ * @author Sean Massung
+ *
+ * All files in META are released under the MIT license. For more details,
+ * consult the file LICENSE in the root of the project.
+ */
+
+#ifndef META_EMBEDDINGS_EMBEDDING_ANALYZER_H_
+#define META_EMBEDDINGS_EMBEDDING_ANALYZER_H_
+
+#include "meta/analyzers/analyzer.h"
+#include "meta/analyzers/analyzer_factory.h"
+#include "meta/embeddings/word_embeddings.h"
+#include "meta/util/clonable.h"
+#include <string>
+
+namespace meta
+{
+namespace analyzers
+{
+
+/**
+ * Analyzes documents by averaging word embeddings for each token.
+ *
+ * Required config parameters:
+ * ~~~toml
+ * [[analyzers]]
+ * method = "embedding" # this analyzer
+ * filter = # use same filter type that embeddings were learned with
+ *
+ * [embeddings]
+ * prefix = "path/to/learned/embeddings"
+ * ~~~
+ *
+ * Optional config parameters: none.
+ */
+class embedding_analyzer : public util::clonable<analyzer, embedding_analyzer>
+{
+  public:
+    /**
+     * Constructor.
+     * @param stream The stream to read tokens from.
+     */
+    embedding_analyzer(const cpptoml::table& config,
+                       std::unique_ptr<token_stream> stream);
+
+    /**
+     * Copy constructor.
+     * @param other The other embedding_analyzer to copy from
+     */
+    embedding_analyzer(const embedding_analyzer& other);
+
+    /// Identifier for this analyzer.
+    const static util::string_view id;
+
+  private:
+    virtual void tokenize(const corpus::document& doc,
+                          featurizer& counts) override;
+
+    /// The token stream to be used for extracting tokens
+    std::unique_ptr<token_stream> stream_;
+
+    /// Learned word embeddings
+    std::shared_ptr<embeddings::word_embeddings> embeddings_;
+};
+
+/**
+ * Specialization of the factory method for creating embedding_analyzers.
+ */
+template <>
+std::unique_ptr<analyzer>
+make_analyzer<embedding_analyzer>(const cpptoml::table&, const cpptoml::table&);
+}
+
+namespace embeddings
+{
+/**
+ * Registers analyzers provided by the meta-embeddings library.
+ */
+void register_analyzers();
+}
+}
+#endif

--- a/include/meta/embeddings/word_embeddings.h
+++ b/include/meta/embeddings/word_embeddings.h
@@ -85,6 +85,11 @@ class word_embeddings
     std::vector<scored_embedding> top_k(util::array_view<const double> query,
                                         std::size_t k = 100) const;
 
+    /**
+     * @return the number of dimensions for each word
+     */
+    std::size_t vector_size() const;
+
   private:
     util::array_view<double> vector(std::size_t tid);
 

--- a/src/classify/tools/CMakeLists.txt
+++ b/src/classify/tools/CMakeLists.txt
@@ -1,9 +1,11 @@
 add_executable(classify classify.cpp)
 target_link_libraries(classify meta-classify
                                meta-sequence-analyzers
-                               meta-parser-analyzers)
+                               meta-parser-analyzers
+                               meta-embeddings-analyzers)
 
 add_executable(online-classify online_classify.cpp)
 target_link_libraries(online-classify meta-classify
                                       meta-sequence-analyzers
-                                      meta-parser-analyzers)
+                                      meta-parser-analyzers
+                                      meta-embeddings-analyzers)

--- a/src/classify/tools/classify.cpp
+++ b/src/classify/tools/classify.cpp
@@ -1,5 +1,7 @@
 /**
- * @file classify-test.cpp
+ * @file classify.cpp
+ * @author Sean Massung
+ * @author Chase Geigle
  */
 
 #include <functional>
@@ -17,9 +19,6 @@
 #include "meta/util/progress.h"
 #include "meta/util/time.h"
 
-using std::cout;
-using std::cerr;
-using std::endl;
 using namespace meta;
 
 template <class Creator>
@@ -27,12 +26,10 @@ classify::confusion_matrix cv(Creator&& creator,
                               classify::multiclass_dataset_view docs, bool even)
 {
     classify::confusion_matrix matrix;
-    auto msec = common::time(
-        [&]()
-        {
-            matrix = classify::cross_validate(std::forward<Creator>(creator),
-                                              docs, 5, even);
-        });
+    auto msec = common::time([&]() {
+        matrix = classify::cross_validate(std::forward<Creator>(creator), docs,
+                                          5, even);
+    });
     std::cerr << "time elapsed: " << msec.count() / 1000.0 << "s" << std::endl;
     matrix.print();
     matrix.print_stats();
@@ -67,7 +64,7 @@ int main(int argc, char* argv[])
 {
     if (argc != 2)
     {
-        cerr << "Usage:\t" << argv[0] << " config.toml" << endl;
+        std::cerr << "Usage:\t" << argv[0] << " config.toml" << std::endl;
         return 1;
     }
 
@@ -81,7 +78,8 @@ int main(int argc, char* argv[])
     auto class_config = config->get_table("classifier");
     if (!class_config)
     {
-        cerr << "Missing classifier configuration group in " << argv[1] << endl;
+        std::cerr << "Missing classifier configuration group in " << argv[1]
+                  << std::endl;
         return 1;
     }
 
@@ -90,14 +88,14 @@ int main(int argc, char* argv[])
     classify::multiclass_dataset dataset{f_idx};
 
     std::function<std::unique_ptr<classify::classifier>(
-        classify::multiclass_dataset_view)> creator;
+        classify::multiclass_dataset_view)>
+        creator;
     auto classifier_method = *class_config->get_as<std::string>("method");
     auto even = class_config->get_as<bool>("even-split").value_or(false);
     if (classifier_method == "knn" || classifier_method == "nearest-centroid")
     {
         auto i_idx = index::make_index<index::inverted_index>(*config);
-        creator = [=](classify::multiclass_dataset_view fold)
-        {
+        creator = [=](classify::multiclass_dataset_view fold) {
             return classify::make_classifier(*class_config, std::move(fold),
                                              i_idx);
         };
@@ -105,8 +103,7 @@ int main(int argc, char* argv[])
     else
     {
 
-        creator = [&](classify::multiclass_dataset_view fold)
-        {
+        creator = [&](classify::multiclass_dataset_view fold) {
             return classify::make_classifier(*class_config, std::move(fold));
         };
     }

--- a/src/classify/tools/classify.cpp
+++ b/src/classify/tools/classify.cpp
@@ -11,6 +11,7 @@
 
 #include "meta/caching/all.h"
 #include "meta/classify/classifier/all.h"
+#include "meta/embeddings/analyzers/embedding_analyzer.h"
 #include "meta/index/forward_index.h"
 #include "meta/index/ranker/all.h"
 #include "meta/parser/analyzers/tree_analyzer.h"
@@ -73,6 +74,7 @@ int main(int argc, char* argv[])
     // Register additional analyzers
     parser::register_analyzers();
     sequence::register_analyzers();
+    embeddings::register_analyzers();
 
     auto config = cpptoml::parse_file(argv[1]);
     auto class_config = config->get_table("classifier");
@@ -102,7 +104,6 @@ int main(int argc, char* argv[])
     }
     else
     {
-
         creator = [&](classify::multiclass_dataset_view fold) {
             return classify::make_classifier(*class_config, std::move(fold));
         };

--- a/src/embeddings/CMakeLists.txt
+++ b/src/embeddings/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(meta-embeddings)
 
 add_subdirectory(tools)
+add_subdirectory(analyzers)
 
 add_library(meta-embeddings word_embeddings.cpp)
 target_link_libraries(meta-embeddings cpptoml meta-util)

--- a/src/embeddings/analyzers/CMakeLists.txt
+++ b/src/embeddings/analyzers/CMakeLists.txt
@@ -1,0 +1,8 @@
+project(meta-embeddings-analyzers)
+
+add_library(meta-embeddings-analyzers embedding_analyzer.cpp)
+target_link_libraries(meta-embeddings-analyzers meta-analyzers meta-embeddings)
+
+install(TARGETS meta-embeddings-analyzers
+        EXPORT meta-exports
+        DESTINATION lib)

--- a/src/embeddings/analyzers/embedding_analyzer.cpp
+++ b/src/embeddings/analyzers/embedding_analyzer.cpp
@@ -48,18 +48,10 @@ void embedding_analyzer::tokenize(const corpus::document& doc,
         ++num_seen;
     }
 
-    // average each feature, take absolute value (why is this good?)
-    for (auto& f : features)
-        f = std::abs(f / num_seen);
-
-    // normalize to 16 digits and record feature values
-    auto max_elem = *std::max_element(features.begin(), features.end());
+    // average each feature and record it
     uint64_t cur_dim = 0;
-    for (const auto& f : features)
-    {
-        auto val = f / max_elem * 1e16;
-        counts(std::to_string(cur_dim++), static_cast<uint64_t>(val));
-    }
+    for (const auto& val : features)
+        counts(std::to_string(cur_dim++), val / num_seen);
 }
 
 template <>

--- a/src/embeddings/analyzers/embedding_analyzer.cpp
+++ b/src/embeddings/analyzers/embedding_analyzer.cpp
@@ -1,0 +1,83 @@
+/**
+ * @file embedding_analyzer.cpp
+ * @author Sean Massung
+ */
+
+#include "meta/analyzers/token_stream.h"
+#include "meta/corpus/document.h"
+#include "meta/embeddings/analyzers/embedding_analyzer.h"
+#include "meta/math/vector.h"
+
+namespace meta
+{
+namespace analyzers
+{
+
+const util::string_view embedding_analyzer::id = "embedding";
+
+embedding_analyzer::embedding_analyzer(const cpptoml::table& config,
+                                       std::unique_ptr<token_stream> stream)
+    : stream_{std::move(stream)}
+
+{
+    auto grp = config.get_table("embeddings");
+    if (!grp)
+        throw std::runtime_error{"[embeddings] section needed in config"};
+
+    embeddings_ = std::make_shared<embeddings::word_embeddings>(
+        embeddings::load_embeddings(*grp));
+}
+
+embedding_analyzer::embedding_analyzer(const embedding_analyzer& other)
+    : stream_{other.stream_->clone()}, embeddings_{other.embeddings_}
+{
+    // nothing
+}
+
+void embedding_analyzer::tokenize(const corpus::document& doc,
+                                  featurizer& counts)
+{
+    using namespace math::operators;
+    stream_->set_content(get_content(doc));
+    std::vector<double> features(embeddings_->vector_size(), 0.0);
+    uint64_t num_seen = 0;
+    while (*stream_)
+    {
+        auto token = stream_->next();
+        features = features + embeddings_->at(token).v;
+        ++num_seen;
+    }
+
+    // average each feature, take absolute value (why is this good?)
+    for (auto& f : features)
+        f = std::abs(f / num_seen);
+
+    // normalize to 16 digits and record feature values
+    auto max_elem = *std::max_element(features.begin(), features.end());
+    uint64_t cur_dim = 0;
+    for (const auto& f : features)
+    {
+        auto val = f / max_elem * 1e16;
+        counts(std::to_string(cur_dim++), static_cast<uint64_t>(val));
+    }
+}
+
+template <>
+std::unique_ptr<analyzer>
+make_analyzer<embedding_analyzer>(const cpptoml::table& global,
+                                  const cpptoml::table& config)
+{
+    auto filts = load_filters(global, config);
+    return make_unique<embedding_analyzer>(global, std::move(filts));
+}
+}
+
+namespace embeddings
+{
+void register_analyzers()
+{
+    using namespace analyzers;
+    register_analyzer<embedding_analyzer>();
+}
+}
+}

--- a/src/embeddings/word_embeddings.cpp
+++ b/src/embeddings/word_embeddings.cpp
@@ -159,6 +159,11 @@ word_embeddings::top_k(util::array_view<const double> query,
     return results.extract_top();
 }
 
+std::size_t word_embeddings::vector_size() const
+{
+    return vector_size_;
+}
+
 word_embeddings load_embeddings(const cpptoml::table& config)
 {
     auto prefix = config.get_as<std::string>("prefix");


### PR DESCRIPTION
This adds an `embedding_analyzer` class that simply represents a document as its averaged word embeddings.

Using the IMDB dataset and 2-fold CV, unigram words get ~88% accuracy and averaged gigaword 300d embeddings get ~80% accuracy (on balanced classes). The `embedding_analyzer` class can be considered a baseline document representation method and can be expanded/improved for future work.

The weirdness with this analyzer is how it converts the averaged vectors to features using the featurizer. If used with an inverted index, the features need to be `uint64_t`s. How the analyzer is written now can work with `inverted_index` by converting the small `double`s to positive 16 digit integers with `abs()`. However, we lose some information. If we keep them as signed doubles, we can actually increase to classification accuracy on IMDB (and presumably other datasets) to ~82%, but the data can't be stored in an inverted index.

What's your opinion on this? Is there some cute way to convert or store these signed doubles as positive integers without using `abs()`? I tried normalization like so:

```cpp
    auto max_elem = *std::max_element(features.begin(), features.end());
    auto min_elem = *std::min_element(features.begin(), features.end());
    uint64_t cur_dim = 0;
    for (const auto& f : features)
    {
        auto val = (f - min_elem) / (max_elem - min_elem) * 1e16;
        counts(std::to_string(cur_dim++), static_cast<uint64_t>(val));
    }
```

But that somehow loses important information and causes the classification accuracy to drop to ~61%. I can't use something like `exp` since that destroys the relative distances between the feature values.