### PR TITLE
Add KL-divergence based pseudo-relevance feedback ranker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ doc/
 data/ceeaus
 data/breast-cancer
 data/housing
+data/cranfield
 biicode.conf
 bii/
 bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,13 +28,15 @@
   The EM algorithm used for the two-component mixture model is provided as
   the `index::feedback::unigram_mixture` free function and returns the
   feedback model.
-- **Breaking Change.** This change also breaks the `ranker` hierarchy into
-  one more level. At the top we have `ranker`, which has a pure virtual
-  function `rank()` that can be overridden to provide entirely custom
-  ranking behavior, This is the class the KL-divergence method derives
-  from, as we need to re-define what it means to rank documents (first
-  retrieving a feedback set, then ranking documents with respect to an
-  updated query).
+- Add the Rocchio algorithm (`rocchio`) for pseudo-relevance feedback in
+  the vector space model.
+- **Breaking Change.** To facilitate the above to changes, we have also
+  broken the `ranker` hierarchy into one more level. At the top we have
+  `ranker`, which has a pure virtual function `rank()` that can be
+  overridden to provide entirely custom ranking behavior, This is the class
+  the KL-divergence and Rocchio methods derive from, as we need to
+  re-define what it means to rank documents (first retrieving a feedback
+  set, then ranking documents with respect to an updated query).
 
   Most of the time, however, you will want to derive from the second level
   `ranking_function`, which is what was called `ranker` before. This class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,52 @@
   and the log-space method. The scaling method is used by default, but the
   log-space method is useful for HMMs with sequence observations to avoid
   underflow issues when the output probabilities themselves are very small.
+- Add the KL-divergence retrieval function using pseudo-relevance feedback
+  with the two-component mixture-model approach of Zhai and Lafferty,
+  called `kl_divergence_prf`. This ranker internally can use any
+  `language_model_ranker` subclass like `dirichlet_prior` or
+  `jelinek_mercer` to perform the ranking of the feedback set and the
+  result documents with respect to the modified query.
+
+  The EM algorithm used for the two-component mixture model is provided as
+  the `index::feedback::unigram_mixture` free function and returns the
+  feedback model.
+- **Breaking Change.** This change also breaks the `ranker` hierarchy into
+  one more level. At the top we have `ranker`, which has a pure virtual
+  function `rank()` that can be overridden to provide entirely custom
+  ranking behavior, This is the class the KL-divergence method derives
+  from, as we need to re-define what it means to rank documents (first
+  retrieving a feedback set, then ranking documents with respect to an
+  updated query).
+
+  Most of the time, however, you will want to derive from the second level
+  `ranking_function`, which is what was called `ranker` before. This class
+  provides a definition of `rank()` to perform document-at-a-time ranking,
+  and expects deriving classes to instead provide `initial_score()` and
+  `score_one()` implementations to define the scoring function used for
+  each document. **Existing code that derived from `ranker` prior to this
+  version of MeTA likely needs to be changed to instead derive from
+  `ranking_function`.**
+- Add the `util::transform_iterator` class and `util::make_transform_iterator`
+  function for providing iterators that transform their output according to
+  a unary function.
 
 ## Enhancements
 - Add additional `packed_write` and `packed_read` overloads: for
   `std::pair`, `stats::dirichlet`, `stats::multinomial`,
   `util::dense_matrix`, and `util::sparse_vector`
+- Additional functions have been added to `ranker_factory` to allow
+  construction/loading of language_model_ranker subclasses (useful for the
+  `kl_divergence_prf` implementation)
+- Add a `util::make_fixed_heap` helper function to simplify the declaration
+  of `util::fixed_heap` classes with lambda function comparators.
+- Add regression tests for rankers MAP and NDCG scores. This adds a new
+  dataset `cranfield` that contains non-binary relevance judgments to
+  facilitate these new tests.
+
+## Bug Fixes
+- Fix bug in NDCG calculation (ideal-DCG was computed using the wrong
+  sorting order for non-binary judgments)
 
 # [v2.4.2][2.4.2]
 ## Bug Fixes

--- a/include/meta/classify/models/linear_model.tcc
+++ b/include/meta/classify/models/linear_model.tcc
@@ -122,17 +122,15 @@ template <class FeatureVector>
 auto linear_model<FeatureId, FeatureValue, ClassId>::best_class(
     FeatureVector&& features) const -> class_id
 {
-    return best_class(std::forward<FeatureVector>(features), [](const class_id&)
-                      {
-        return true;
-    });
+    return best_class(std::forward<FeatureVector>(features),
+                      [](const class_id&) { return true; });
 }
 
 template <class FeatureId, class FeatureValue, class ClassId>
 template <class FeatureVector, class Filter>
 auto linear_model<FeatureId, FeatureValue, ClassId>::best_classes(
-    FeatureVector&& features, uint64_t num,
-    Filter&& filter) const -> scored_classes
+    FeatureVector&& features, uint64_t num, Filter&& filter) const
+    -> scored_classes
 {
     weight_vector class_scores;
     for (const auto& feat : features)
@@ -153,12 +151,10 @@ auto linear_model<FeatureId, FeatureValue, ClassId>::best_classes(
         }
     }
 
-    auto comp = [](const scored_class& lhs, const scored_class& rhs)
-    {
-        return lhs.second > rhs.second;
-    };
-
-    util::fixed_heap<scored_class, decltype(comp)> heap{num, comp};
+    auto heap = util::make_fixed_heap<scored_class>(
+        num, [](const scored_class& lhs, const scored_class& rhs) {
+            return lhs.second > rhs.second;
+        });
     for (const auto& score : class_scores)
     {
         auto cid = score.first;
@@ -175,10 +171,7 @@ auto linear_model<FeatureId, FeatureValue, ClassId>::best_classes(
     FeatureVector&& features, uint64_t num) const -> scored_classes
 {
     return best_classes(std::forward<FeatureVector>(features), num,
-                        [](const class_id&)
-                        {
-        return true;
-    });
+                        [](const class_id&) { return true; });
 }
 
 template <class FeatureId, class FeatureValue, class ClassId>
@@ -230,8 +223,8 @@ void linear_model<FeatureId, FeatureValue, ClassId>::condense(bool log)
 }
 
 template <class FeatureId, class FeatureValue, class ClassId>
-auto linear_model<FeatureId, FeatureValue, ClassId>::weights() const -> const
-    weight_vectors &
+auto linear_model<FeatureId, FeatureValue, ClassId>::weights() const
+    -> const weight_vectors&
 {
     return weights_;
 }

--- a/include/meta/index/ranker/all.h
+++ b/include/meta/index/ranker/all.h
@@ -5,3 +5,4 @@
 #include "meta/index/ranker/lm_ranker.h"
 #include "meta/index/ranker/okapi_bm25.h"
 #include "meta/index/ranker/pivoted_length.h"
+#include "meta/index/ranker/kl_divergence_prf.h"

--- a/include/meta/index/ranker/all.h
+++ b/include/meta/index/ranker/all.h
@@ -6,3 +6,4 @@
 #include "meta/index/ranker/okapi_bm25.h"
 #include "meta/index/ranker/pivoted_length.h"
 #include "meta/index/ranker/kl_divergence_prf.h"
+#include "meta/index/ranker/rocchio.h"

--- a/include/meta/index/ranker/kl_divergence_prf.h
+++ b/include/meta/index/ranker/kl_divergence_prf.h
@@ -37,7 +37,7 @@ namespace index
  * k = 10         # number of feedback documents to retrieve
  * max-terms = 50 # maximum number of feedback terms to use
  *
- * [ranker.initial]
+ * [ranker.feedback]
  * method = "dirichlet-prior" # the initial model used to retrieve documents
  * # other parameters for that initial retrieval method
  * ~~~

--- a/include/meta/index/ranker/kl_divergence_prf.h
+++ b/include/meta/index/ranker/kl_divergence_prf.h
@@ -1,0 +1,92 @@
+/**
+ * @file kl_divergence_prf.h
+ * @author Chase Geigle
+ *
+ * All files in META are dual-licensed under the MIT and NCSA licenses. For more
+ * details, consult the file LICENSE.mit and LICENSE.ncsa in the root of the
+ * project.
+ */
+
+#ifndef META_INDEX_KL_DIVERGENCE_PRF_H_
+#define META_INDEX_KL_DIVERGENCE_PRF_H_
+
+#include "meta/index/ranker/lm_ranker.h"
+#include "meta/index/ranker/ranker_factory.h"
+
+namespace meta
+{
+namespace index
+{
+
+/**
+ * Implements the two-component mixture model for pseudo-relevance
+ * feedback in the KL-divergence retrieval model.
+ *
+ * @see http://dl.acm.org/citation.cfm?id=502654
+ *
+ * Required config parameters:
+ * ~~~toml
+ * [ranker]
+ * method = "kl-divergence-prf"
+ * ~~~
+ *
+ * Optional config parameters:
+ * ~~~toml
+ * alpha = 0.5  # query interpolation parameter
+ * lambda = 0.5 # mixture model interpolation parameter
+ * k = 10       # number of feedback documents to retrieve
+ *
+ * [ranker.initial]
+ * method = "dirichlet-prior" # the initial model used to retrieve documents
+ * # other parameters for that initial retrieval method
+ * ~~~
+ */
+class kl_divergence_prf : public ranker
+{
+  public:
+    /// Identifier for this ranker.
+    const static util::string_view id;
+
+    /// Default value of alpha, the query interpolation parameter
+    const static constexpr float default_alpha = 0.5;
+
+    /// Default value for lambda, the mixture model interpolation parameter
+    const static constexpr float default_lambda = 0.5;
+
+    /// Default value for k, the number of feedback documents to retrieve
+    const static constexpr uint64_t default_k = 10;
+
+    kl_divergence_prf(std::shared_ptr<forward_index> fwd);
+
+    kl_divergence_prf(std::shared_ptr<forward_index> fwd,
+                      std::unique_ptr<language_model_ranker>&& initial_ranker,
+                      float alpha = default_alpha,
+                      float lambda = default_lambda, uint64_t k = default_k);
+
+    kl_divergence_prf(std::istream& in);
+
+    void save(std::ostream& out) const override;
+
+    std::vector<search_result>
+    rank(ranker_context& ctx, uint64_t num_results,
+         const filter_function_type& filter) override;
+
+  private:
+    std::shared_ptr<forward_index> fwd_;
+    std::unique_ptr<language_model_ranker> initial_ranker_;
+    const float alpha_;
+    const float lambda_;
+    const uint64_t k_;
+};
+
+/**
+ * Specialization of the factory method used to create kl_divergence_prf
+ * rankers.
+ */
+template <>
+std::unique_ptr<ranker>
+make_ranker<kl_divergence_prf>(const cpptoml::table& global,
+                               const cpptoml::table& local);
+}
+}
+#endif

--- a/include/meta/index/ranker/kl_divergence_prf.h
+++ b/include/meta/index/ranker/kl_divergence_prf.h
@@ -32,9 +32,10 @@ namespace index
  *
  * Optional config parameters:
  * ~~~toml
- * alpha = 0.5  # query interpolation parameter
- * lambda = 0.5 # mixture model interpolation parameter
- * k = 10       # number of feedback documents to retrieve
+ * alpha = 0.5    # query interpolation parameter
+ * lambda = 0.5   # mixture model interpolation parameter
+ * k = 10         # number of feedback documents to retrieve
+ * max-terms = 50 # maximum number of feedback terms to use
  *
  * [ranker.initial]
  * method = "dirichlet-prior" # the initial model used to retrieve documents
@@ -56,12 +57,19 @@ class kl_divergence_prf : public ranker
     /// Default value for k, the number of feedback documents to retrieve
     const static constexpr uint64_t default_k = 10;
 
+    /**
+     * Default value for max_terms, the number of feedback terms to
+     * interpolate into the query model.
+     */
+    const static constexpr uint64_t default_max_terms = 50;
+
     kl_divergence_prf(std::shared_ptr<forward_index> fwd);
 
     kl_divergence_prf(std::shared_ptr<forward_index> fwd,
                       std::unique_ptr<language_model_ranker>&& initial_ranker,
                       float alpha = default_alpha,
-                      float lambda = default_lambda, uint64_t k = default_k);
+                      float lambda = default_lambda, uint64_t k = default_k,
+                      uint64_t max_terms = default_max_terms);
 
     kl_divergence_prf(std::istream& in);
 
@@ -77,6 +85,7 @@ class kl_divergence_prf : public ranker
     const float alpha_;
     const float lambda_;
     const uint64_t k_;
+    const uint64_t max_terms_;
 };
 
 /**

--- a/include/meta/index/ranker/lm_ranker.h
+++ b/include/meta/index/ranker/lm_ranker.h
@@ -22,7 +22,7 @@ namespace index
  * scoring methods described in "A Study of Smoothing Methods for Language
  * Models Applied to Ad Hoc Information Retrieval" by Zhai and Lafferty, 2001.
  */
-class language_model_ranker : public ranker
+class language_model_ranker : public ranking_function
 {
   public:
     /// The identifier for this ranker.

--- a/include/meta/index/ranker/okapi_bm25.h
+++ b/include/meta/index/ranker/okapi_bm25.h
@@ -33,7 +33,7 @@ namespace index
  * k3 = 500.0
  * ~~~
  */
-class okapi_bm25 : public ranker
+class okapi_bm25 : public ranking_function
 {
   public:
     /// The identifier for this ranker.

--- a/include/meta/index/ranker/pivoted_length.h
+++ b/include/meta/index/ranker/pivoted_length.h
@@ -33,7 +33,7 @@ namespace index
  * s = 0.2
  * ~~~
  */
-class pivoted_length : public ranker
+class pivoted_length : public ranking_function
 {
   public:
     /// Identifier for this ranker.

--- a/include/meta/index/ranker/rocchio.h
+++ b/include/meta/index/ranker/rocchio.h
@@ -1,0 +1,101 @@
+/**
+ * @file rocchio.h
+ * @author Chase Geigle
+ *
+ * All files in META are dual-licensed under the MIT and NCSA licenses. For more
+ * details, consult the file LICENSE.mit and LICENSE.ncsa in the root of the
+ * project.
+ */
+
+#ifndef META_INDEX_ROCCHIO_H_
+#define META_INDEX_ROCCHIO_H_
+
+#include "meta/index/ranker/ranker_factory.h"
+
+namespace meta
+{
+namespace index
+{
+
+/**
+ * Implements the Rocchio algorithm for pseudo-relevance feedback. This
+ * implementation considers only positive documents for feedback. The top
+ * `max_terms` from the centroid of the feedback set are selected according
+ * to their weights provided by the wrapped ranker's `score_one` function.
+ * These are then interpolated into the query in *count space*, and then
+ * the results from running the wrapped ranker on the new query are
+ * returned.
+ *
+ * Required config parameters:
+ * ~~~toml
+ * [ranker]
+ * method = "rocchio"
+ * ~~~
+ *
+ * Optional config parameters:
+ * ~~~toml
+ * alpha = 1.0    # original query weight parameter
+ * beta = 1.0     # feedback document weight parameter
+ * k = 10         # number of feedback documents to retrieve
+ * max-terms = 50 # maximum number of feedback terms to use
+ * [ranker.feedback]
+ * method = # whatever ranker method you want to wrap
+ * # other parameters for that ranker
+ * ~~~
+ *
+ * @see https://en.wikipedia.org/wiki/Rocchio_algorithm
+ */
+class rocchio : public ranker
+{
+  public:
+    /// Identifier for this ranker.
+    const static util::string_view id;
+
+    /// Default value of alpha, the original query weight parameter
+    const static constexpr float default_alpha = 1.0f;
+
+    /// Default value of beta, the positive document weight parameter
+    const static constexpr float default_beta = 0.8f;
+
+    /// Default value for k, the number of feedback documents to retrieve
+    const static constexpr uint64_t default_k = 10;
+
+    /**
+     * Default value for max_terms, the number of new terms to add to the
+     * new query.
+     */
+    const static constexpr uint64_t default_max_terms = 50;
+
+    rocchio(std::shared_ptr<forward_index> fwd);
+
+    rocchio(std::shared_ptr<forward_index> fwd,
+            std::unique_ptr<ranker>&& initial_ranker,
+            float alpha = default_alpha, float beta = default_beta,
+            uint64_t k = default_k, uint64_t max_terms = default_max_terms);
+
+    rocchio(std::istream& in);
+
+    void save(std::ostream& out) const override;
+
+    std::vector<search_result>
+    rank(ranker_context& ctx, uint64_t num_results,
+         const filter_function_type& filter) override;
+
+  private:
+    std::shared_ptr<forward_index> fwd_;
+    std::unique_ptr<ranker> initial_ranker_;
+    const float alpha_;
+    const float beta_;
+    const uint64_t k_;
+    const uint64_t max_terms_;
+};
+
+/**
+ * Specialization of the factory method used to create rocchio rankers.
+ */
+template <>
+std::unique_ptr<ranker> make_ranker<rocchio>(const cpptoml::table& global,
+                                             const cpptoml::table& local);
+}
+}
+#endif

--- a/include/meta/index/ranker/unigram_mixture.h
+++ b/include/meta/index/ranker/unigram_mixture.h
@@ -1,0 +1,111 @@
+/**
+ * @file unigram_mixture.h
+ * @author Chase Geigle
+ *
+ * All files in META are dual-licensed under the MIT and NCSA licenses. For more
+ * details, consult the file LICENSE.mit and LICENSE.ncsa in the root of the
+ * project.
+ */
+
+#ifndef UNIGRAM_MIXTURE_H_
+#define UNIGRAM_MIXTURE_H_
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+
+#include "meta/config.h"
+#include "meta/learn/dataset_view.h"
+#include "meta/stats/multinomial.h"
+
+namespace meta
+{
+namespace index
+{
+namespace feedback
+{
+
+/**
+ * @param dset A collection of documents to fit a language model to
+ * @return the maximum likelihood estimate for the language model
+ */
+stats::multinomial<term_id> maximum_likelihood(const learn::dataset_view& dset)
+{
+    stats::multinomial<term_id> model;
+    for (const auto& inst : dset)
+    {
+        for (const auto& weight : inst.weights)
+        {
+            model.increment(weight.first, weight.second);
+        }
+    }
+    return model;
+}
+
+struct training_options
+{
+    /// The fixed probability of the background model
+    double lambda = 0.5;
+    /// The maximum number of iterations for running EM
+    uint64_t max_iter = 50;
+    /// The convergence threshold as the relative change in log likelihood
+    double delta = 1e-5;
+};
+
+/**
+ * Learns the feedback model component of a two-component unigram mixture
+ * model. The BackgroundModel is a unary function that returns the
+ * probability of a term. This is used as the first component of the
+ * mixture model, which has fixed probability options.lambda of being
+ * selected. This function used the EM algorithm to fit the second
+ * component language model and returns it.
+ *
+ * @param background The background language model
+ * @param dset The feedback documents to fit the feedback model to
+ * @param options The training options for the EM algorithm
+ * @return the feedback model
+ */
+template <class BackgroundModel>
+stats::multinomial<term_id>
+unigram_mixture(BackgroundModel&& background, const learn::dataset_view& dset,
+                const training_options& options = {})
+{
+    auto feedback = maximum_likelihood(dset);
+    auto old_ll = std::numeric_limits<double>::lowest();
+    auto relative_change = std::numeric_limits<double>::max();
+
+    for (uint64_t i = 1;
+         i <= options.max_iter && relative_change >= options.delta; ++i)
+    {
+        stats::multinomial<term_id> model;
+        double ll = 0;
+
+        for (const auto& inst : dset)
+        {
+            for (const auto& weight : inst.weights)
+            {
+                auto p_wc = background(weight.first);
+                auto p_wf = feedback.probability(weight.first);
+
+                auto numerator = options.lambda * p_wc;
+                auto denominator = numerator + (1.0 - options.lambda) * p_wf;
+
+                auto p_zw = numerator / denominator;
+
+                model.increment(weight.first, (1.0 - p_zw) * weight.second);
+                ll += weight.second * std::log(denominator);
+            }
+        }
+
+        feedback = model;
+        assert(ll > old_ll);
+        relative_change = (old_ll - ll) / old_ll;
+        old_ll = ll;
+    }
+
+    return feedback;
+}
+}
+}
+}
+#endif

--- a/include/meta/learn/dataset.h
+++ b/include/meta/learn/dataset.h
@@ -41,9 +41,10 @@ class dataset
      * Creates an in-memory dataset from a forward_index and a range of
      * doc_ids, represented as iterators.
      */
-    template <class ForwardIterator>
+    template <class ForwardIterator,
+              class ProgressTrait = printing::default_progress_trait>
     dataset(std::shared_ptr<index::forward_index> idx, ForwardIterator begin,
-            ForwardIterator end)
+            ForwardIterator end, ProgressTrait = ProgressTrait{})
         : total_features_{idx->unique_terms()}
     {
         auto size = static_cast<uint64_t>(std::distance(begin, end));
@@ -53,7 +54,8 @@ class dataset
 
         instances_.reserve(size);
 
-        printing::progress progress{" > Loading instances into memory: ", size};
+        typename ProgressTrait::type progress{
+            " > Loading instances into memory: ", size};
         for (auto doc = 0_inst_id; begin != end; ++begin, ++doc)
         {
             progress(doc);
@@ -70,15 +72,17 @@ class dataset
      * the knn classifier. The id field of the instance_types stored within
      * the dataset is a document_id.
      */
-    template <class ForwardIterator>
+    template <class ForwardIterator,
+              class ProgressTrait = printing::default_progress_trait>
     dataset(std::shared_ptr<index::inverted_index> idx, ForwardIterator begin,
-            ForwardIterator end)
+            ForwardIterator end, ProgressTrait = ProgressTrait{})
         : total_features_{idx->unique_terms()}
     {
         auto size = static_cast<uint64_t>(std::distance(begin, end));
         instances_.reserve(size);
 
-        printing::progress progress{" > Loading instances into memory: ", size};
+        typename ProgressTrait::type progress{
+            " > Loading instances into memory: ", size};
         for (uint64_t pos = 0; begin != end; ++begin, ++pos)
         {
             progress(pos);

--- a/include/meta/learn/transform.h
+++ b/include/meta/learn/transform.h
@@ -22,7 +22,7 @@ namespace learn
  * Transformer for converting term frequency vectors into tf-idf weight
  * vectors. This transformation is performed with respect to a specific
  * index::inverted_index that defines the term statistics, and with respect
- * to an index::ranker that defines the "tf-idf" weight (via its
+ * to an index::ranking_function that defines the "tf-idf" weight (via its
  * score_one() function).
  *
  * For example, one can construct a tfidf_transformer with an
@@ -55,7 +55,7 @@ class tfidf_transformer
      * @param idx The index to use for term statistics
      * @param r The ranker to use for defining the weights
      */
-    tfidf_transformer(index::inverted_index& idx, index::ranker& r)
+    tfidf_transformer(index::inverted_index& idx, index::ranking_function& r)
         : idx_(idx),
           rnk_(r),
           sdata_(idx, idx.avg_doc_length(), idx.num_docs(),
@@ -89,7 +89,7 @@ class tfidf_transformer
 
   private:
     index::inverted_index& idx_;
-    index::ranker& rnk_;
+    index::ranking_function& rnk_;
     index::score_data sdata_;
 };
 
@@ -140,7 +140,7 @@ void transform(dataset& dset, TransformFunction&& trans)
  * score_one())
  */
 void tfidf_transform(dataset& dset, index::inverted_index& idx,
-                     index::ranker& rnk)
+                     index::ranking_function& rnk)
 {
     tfidf_transformer transformer{idx, rnk};
     transform(dset, transformer);

--- a/include/meta/util/fixed_heap.h
+++ b/include/meta/util/fixed_heap.h
@@ -91,6 +91,18 @@ class fixed_heap
     Comp comp_;
     std::vector<T> pq_;
 };
+
+/**
+ * Constructs a fixed_heap from a maximum size and binary comparison
+ * function.
+ */
+template <class T, class BinaryFunction>
+fixed_heap<T, BinaryFunction> make_fixed_heap(uint64_t max_elems,
+                                              BinaryFunction&& bf)
+{
+    return fixed_heap<T, BinaryFunction>(max_elems,
+                                         std::forward<BinaryFunction>(bf));
+}
 }
 }
 

--- a/include/meta/util/iterator.h
+++ b/include/meta/util/iterator.h
@@ -1,0 +1,129 @@
+/**
+ * @file iterator.h
+ * @author Chase Geigle
+ *
+ * All files in META are dual-licensed under the MIT and NCSA licenses. For more
+ * details, consult the file LICENSE.mit and LICENSE.ncsa in the root of the
+ * project.
+ */
+
+#ifndef META_UTIL_ITERATOR_H_
+#define META_UTIL_ITERATOR_H_
+
+#include <iterator>
+#include <type_traits>
+
+#include "meta/config.h"
+#include "meta/util/comparable.h"
+
+namespace meta
+{
+namespace util
+{
+
+template <class Iterator, class UnaryFunction>
+class transform_iterator
+    : public comparable<transform_iterator<Iterator, UnaryFunction>>
+{
+  public:
+    using traits_type = std::iterator_traits<Iterator>;
+    using difference_type = typename traits_type::difference_type;
+    using value_type = typename std::result_of<UnaryFunction(
+        typename traits_type::reference)>::type;
+    using pointer = typename std::add_pointer<value_type>::type;
+    using reference =
+        typename std::add_lvalue_reference<const value_type>::type;
+    using iterator_category = typename traits_type::iterator_category;
+
+    transform_iterator(Iterator it, UnaryFunction fun) : it_{it}, fun_{fun}
+    {
+        // nothing
+    }
+
+    transform_iterator& operator++()
+    {
+        ++it_;
+        return *this;
+    }
+
+    transform_iterator operator++(int)
+    {
+        auto tmp = *this;
+        ++it_;
+        return tmp;
+    }
+
+    transform_iterator& operator--()
+    {
+        --it_;
+        return *this;
+    }
+
+    transform_iterator operator--(int)
+    {
+        auto tmp = *this;
+        --it_;
+        return *tmp;
+    }
+
+    transform_iterator& operator+=(difference_type diff)
+    {
+        it_ += diff;
+        return *this;
+    }
+
+    transform_iterator operator+(difference_type diff) const
+    {
+        auto tmp = *this;
+        tmp += diff;
+        return tmp;
+    }
+
+    transform_iterator& operator-=(difference_type diff)
+    {
+        it_ -= diff;
+        return *this;
+    }
+
+    transform_iterator operator-(difference_type diff) const
+    {
+        auto tmp = *this;
+        tmp -= diff;
+        return tmp;
+    }
+
+    difference_type operator-(transform_iterator other) const
+    {
+        return it_ - other.it_;
+    }
+
+    reference operator[](difference_type diff) const
+    {
+        return fun_(it_[diff]);
+    }
+
+    bool operator<(transform_iterator other) const
+    {
+        return it_ < other.it_;
+    }
+
+    value_type operator*() const
+    {
+        return fun_(*it_);
+    }
+
+  private:
+    Iterator it_;
+    UnaryFunction fun_;
+};
+
+template <class Iterator, class UnaryFunction>
+transform_iterator<Iterator, UnaryFunction>
+make_transform_iterator(Iterator it, UnaryFunction&& fun)
+{
+    return transform_iterator<Iterator, UnaryFunction>(
+        it, std::forward<UnaryFunction>(fun));
+}
+}
+}
+#endif

--- a/include/meta/util/iterator.h
+++ b/include/meta/util/iterator.h
@@ -21,6 +21,10 @@ namespace meta
 namespace util
 {
 
+/**
+ * Wrapper around an Iterator that, when dereferenced, returns f(*it)
+ * where `it` is the wrapped Iterator and `f` is a UnaryFunction.
+ */
 template <class Iterator, class UnaryFunction>
 class transform_iterator
     : public comparable<transform_iterator<Iterator, UnaryFunction>>
@@ -35,7 +39,7 @@ class transform_iterator
         typename std::add_lvalue_reference<const value_type>::type;
     using iterator_category = typename traits_type::iterator_category;
 
-    transform_iterator(Iterator it, UnaryFunction fun) : it_{it}, fun_{fun}
+    transform_iterator(Iterator it, UnaryFunction fun) : it_{it}, fun_(fun)
     {
         // nothing
     }
@@ -117,6 +121,10 @@ class transform_iterator
     UnaryFunction fun_;
 };
 
+/**
+ * Helper function to construct a transform_iterator from an Iterator and
+ * a UnaryFunction to transform the values of that Iterator.
+ */
 template <class Iterator, class UnaryFunction>
 transform_iterator<Iterator, UnaryFunction>
 make_transform_iterator(Iterator it, UnaryFunction&& fun)

--- a/include/meta/util/progress.h
+++ b/include/meta/util/progress.h
@@ -18,6 +18,7 @@
 #include <thread>
 
 #include "meta/config.h"
+#include "meta/util/string_view.h"
 
 namespace meta
 {
@@ -100,6 +101,36 @@ class progress
     const int interval_;
     /// Whether or not we should print an endline when done.
     bool endline_;
+};
+
+/**
+ * Class adhering to the progress API that can be substituted for it when
+ * no progress output is desired.
+ */
+class null_progress
+{
+  public:
+    null_progress(util::string_view prefix, uint64_t length, int interval = 500)
+    {
+        (void)prefix;
+        (void)length;
+        (void)interval;
+    }
+
+    void operator()(uint64_t iter)
+    {
+        (void)iter;
+    }
+};
+
+struct default_progress_trait
+{
+    using type = progress;
+};
+
+struct no_progress_trait
+{
+    using type = null_progress;
 };
 }
 }

--- a/src/embeddings/word_embeddings.cpp
+++ b/src/embeddings/word_embeddings.cpp
@@ -39,10 +39,8 @@ word_embeddings::word_embeddings(std::istream& vocab, std::istream& vectors)
 
         progress(tid);
         auto vec = vector(tid);
-        std::generate(vec.begin(), vec.end(), [&]()
-                      {
-                          return io::packed::read<double>(vectors);
-                      });
+        std::generate(vec.begin(), vec.end(),
+                      [&]() { return io::packed::read<double>(vectors); });
     }
 }
 
@@ -73,16 +71,13 @@ word_embeddings::word_embeddings(std::istream& vocab, std::istream& first,
 
         progress(tid);
         auto vec = vector(tid);
-        std::generate(vec.begin(), vec.end(), [&]()
-                      {
-                          return (io::packed::read<double>(first)
-                                  + io::packed::read<double>(second));
-                      });
+        std::generate(vec.begin(), vec.end(), [&]() {
+            return (io::packed::read<double>(first)
+                    + io::packed::read<double>(second));
+        });
         auto len = math::operators::l2norm(vec);
-        std::transform(vec.begin(), vec.end(), vec.begin(), [=](double weight)
-                {
-                    return weight / len;
-                });
+        std::transform(vec.begin(), vec.end(), vec.begin(),
+                       [=](double weight) { return weight / len; });
     }
 }
 
@@ -139,11 +134,10 @@ std::vector<scored_embedding>
 word_embeddings::top_k(util::array_view<const double> query,
                        std::size_t k) const
 {
-    auto comp = [](const scored_embedding& a, const scored_embedding& b)
-    {
-        return a.score > b.score;
-    };
-    util::fixed_heap<scored_embedding, decltype(comp)> results{k, comp};
+    auto results = util::make_fixed_heap<scored_embedding>(
+        k, [](const scored_embedding& a, const scored_embedding& b) {
+            return a.score > b.score;
+        });
 
     // +1 for <unk>
     for (std::size_t tid = 0; tid < id_to_term_.size() + 1; ++tid)

--- a/src/index/eval/ir_eval.cpp
+++ b/src/index/eval/ir_eval.cpp
@@ -145,7 +145,7 @@ double ir_eval::ndcg(const std::vector<search_result>& results, query_id q_id,
     std::vector<uint64_t> rels;
     for (const auto& s : ht->second)
         rels.push_back(s.second);
-    std::sort(rels.begin(), rels.end());
+    std::sort(rels.begin(), rels.end(), std::greater<uint64_t>{});
 
     double idcg = 0.0;
     i = 1;

--- a/src/index/forward_index.cpp
+++ b/src/index/forward_index.cpp
@@ -571,9 +571,12 @@ void forward_index::impl::uninvert(const inverted_index& inv_idx,
 {
     postings_inverter<forward_index> handler{idx_->index_name()};
     {
+        printing::progress progress{" > Uninverting postings: ",
+                                    inv_idx.unique_terms()};
         auto producer = handler.make_producer(ram_budget);
         for (term_id t_id{0}; t_id < inv_idx.unique_terms(); ++t_id)
         {
+            progress(t_id);
             auto pdata = inv_idx.search_primary(t_id);
             producer(pdata->primary_key(), pdata->counts());
         }

--- a/src/index/ranker/CMakeLists.txt
+++ b/src/index/ranker/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(meta-ranker absolute_discount.cpp
                         lm_ranker.cpp
                         okapi_bm25.cpp
                         pivoted_length.cpp
+                        kl_divergence_prf.cpp
                         ranker.cpp
                         ranker_factory.cpp)
 target_link_libraries(meta-ranker meta-index)

--- a/src/index/ranker/CMakeLists.txt
+++ b/src/index/ranker/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(meta-ranker absolute_discount.cpp
                         okapi_bm25.cpp
                         pivoted_length.cpp
                         kl_divergence_prf.cpp
+                        rocchio.cpp
                         ranker.cpp
                         ranker_factory.cpp)
 target_link_libraries(meta-ranker meta-index)

--- a/src/index/ranker/kl_divergence_prf.cpp
+++ b/src/index/ranker/kl_divergence_prf.cpp
@@ -1,0 +1,144 @@
+/**
+ * @file kl_divergence_prf.cpp
+ * @author Chase Geigle
+ */
+
+#include <stdexcept>
+
+#include "cpptoml.h"
+#include "meta/index/ranker/dirichlet_prior.h"
+#include "meta/index/ranker/kl_divergence_prf.h"
+#include "meta/index/ranker/unigram_mixture.h"
+#include "meta/index/score_data.h"
+#include "meta/io/packed.h"
+#include "meta/logging/logger.h"
+#include "meta/util/iterator.h"
+#include "meta/util/shim.h"
+
+namespace meta
+{
+namespace index
+{
+
+const util::string_view kl_divergence_prf::id = "kl-divergence-prf";
+const constexpr float kl_divergence_prf::default_alpha;
+const constexpr float kl_divergence_prf::default_lambda;
+const constexpr uint64_t kl_divergence_prf::default_k;
+
+kl_divergence_prf::kl_divergence_prf(std::shared_ptr<forward_index> fwd)
+    : fwd_{std::move(fwd)},
+      initial_ranker_{make_unique<dirichlet_prior>()},
+      alpha_{default_alpha},
+      lambda_{default_lambda},
+      k_{default_k}
+{
+    // nothing
+}
+
+kl_divergence_prf::kl_divergence_prf(
+    std::shared_ptr<forward_index> fwd,
+    std::unique_ptr<language_model_ranker>&& initial_ranker, float alpha,
+    float lambda, uint64_t k)
+    : fwd_{std::move(fwd)},
+      initial_ranker_{std::move(initial_ranker)},
+      alpha_{alpha},
+      lambda_{lambda},
+      k_{k}
+{
+    // nothing
+}
+
+kl_divergence_prf::kl_divergence_prf(std::istream& in)
+    : fwd_{[&]() {
+          auto path = io::packed::read<std::string>(in);
+          auto cfg = cpptoml::parse_file(path + "/config.toml");
+          return make_index<forward_index>(*cfg);
+      }()},
+      initial_ranker_{load_lm_ranker(in)},
+      alpha_{io::packed::read<float>(in)},
+      lambda_{io::packed::read<float>(in)},
+      k_{io::packed::read<uint64_t>(in)}
+{
+    // nothing
+}
+
+void kl_divergence_prf::save(std::ostream& out) const
+{
+    io::packed::write(out, id);
+    io::packed::write(out, fwd_->index_name());
+    initial_ranker_->save(out);
+    io::packed::write(out, alpha_);
+    io::packed::write(out, lambda_);
+    io::packed::write(out, k_);
+}
+
+std::vector<search_result>
+kl_divergence_prf::rank(ranker_context& ctx, uint64_t num_results,
+                        const filter_function_type& filter)
+{
+    auto fb_docs = initial_ranker_->rank(ctx, k_, filter);
+    auto extract_docid = [](const search_result& sr) { return sr.d_id; };
+
+    // construct feedback document set
+    learn::dataset fb_dset{
+        fwd_, util::make_transform_iterator(fb_docs.begin(), extract_docid),
+        util::make_transform_iterator(fb_docs.end(), extract_docid),
+        printing::no_progress_trait{}};
+
+    // learn the feedback model using the EM algorithm
+    feedback::training_options options;
+    options.lambda = lambda_;
+    auto fb_model = feedback::unigram_mixture(
+        [&](term_id tid) {
+            float term_count = ctx.idx.total_num_occurences(tid);
+            return term_count / ctx.idx.total_corpus_terms();
+        },
+        fb_dset, options);
+
+    // interpolate the query model with the feedback model
+    hashing::probe_map<term_id, float> new_query;
+    fb_model.each_seen_event([&](term_id tid) {
+        new_query[tid] += alpha_ * fb_model.probability(tid);
+    });
+    for (const auto& postings_ctx : ctx.postings)
+    {
+        auto p_wq = postings_ctx.query_term_weight / ctx.query_length;
+        new_query[postings_ctx.t_id] += (1.0f - alpha_) * p_wq;
+    }
+
+    // construct a new ranker_context from the new query
+    ranker_context new_ctx{ctx.idx, new_query.begin(), new_query.end(), filter};
+
+    // return ranking results based on the new query
+    return initial_ranker_->rank(new_ctx, num_results, filter);
+}
+
+template <>
+std::unique_ptr<ranker>
+make_ranker<kl_divergence_prf>(const cpptoml::table& global,
+                               const cpptoml::table& local)
+{
+    if (global.begin() == global.end())
+    {
+        LOG(fatal) << "Global configuration group was empty in construction of "
+                      "kl_divergence_prf ranker"
+                   << ENDLG;
+        LOG(fatal) << "Did you mean to call index::make_ranker(global, local) "
+                      "instead of index::make_ranker(local)?"
+                   << ENDLG;
+        throw ranker_exception{"empty global configuration provided to "
+                               "construction of kl_divergence_prf ranker"};
+    }
+
+    auto alpha = local.get_as<double>("alpha").value_or(
+        kl_divergence_prf::default_alpha);
+    auto lambda = local.get_as<double>("lambda").value_or(
+        kl_divergence_prf::default_lambda);
+    auto k = local.get_as<uint64_t>("k").value_or(kl_divergence_prf::default_k);
+    auto init_cfg = local.get_table("feedback");
+    auto f_idx = make_index<forward_index>(global);
+    return make_unique<kl_divergence_prf>(
+        std::move(f_idx), make_lm_ranker(global, *init_cfg), alpha, lambda, k);
+}
+}
+}

--- a/src/index/ranker/ranker.cpp
+++ b/src/index/ranker/ranker.cpp
@@ -4,7 +4,6 @@
  * @author Chase Geigle
  */
 
-#include <unordered_map>
 #include "meta/corpus/document.h"
 #include "meta/index/inverted_index.h"
 #include "meta/index/postings_data.h"
@@ -18,23 +17,22 @@ namespace index
 {
 
 std::vector<search_result>
-    ranker::score(inverted_index& idx, const corpus::document& query,
-                  uint64_t num_results /* = 10 */,
-                  const filter_function_type& filter /* return true */)
+ranker::score(inverted_index& idx, const corpus::document& query,
+              uint64_t num_results /* = 10 */,
+              const filter_function_type& filter /* return true */)
 {
     auto counts = idx.tokenize(query);
     return score(idx, counts.begin(), counts.end(), num_results, filter);
 }
 
-std::vector<search_result> ranker::rank(detail::ranker_context& ctx,
-                                        uint64_t num_results,
-                                        const filter_function_type& filter)
+std::vector<search_result>
+ranking_function::rank(ranker_context& ctx, uint64_t num_results,
+                       const filter_function_type& filter)
 {
     score_data sd{ctx.idx, ctx.idx.avg_doc_length(), ctx.idx.num_docs(),
                   ctx.idx.total_corpus_terms(), ctx.query_length};
 
-    auto comp = [](const search_result& a, const search_result& b)
-    {
+    auto comp = [](const search_result& a, const search_result& b) {
         // comparison is reversed since we want a min-heap
         return a.score > b.score;
     };
@@ -89,7 +87,7 @@ std::vector<search_result> ranker::rank(detail::ranker_context& ctx,
     return results.extract_top();
 }
 
-float ranker::initial_score(const score_data&) const
+float ranking_function::initial_score(const score_data&) const
 {
     return 0.0;
 }

--- a/src/index/ranker/ranker.cpp
+++ b/src/index/ranker/ranker.cpp
@@ -32,11 +32,11 @@ ranking_function::rank(ranker_context& ctx, uint64_t num_results,
     score_data sd{ctx.idx, ctx.idx.avg_doc_length(), ctx.idx.num_docs(),
                   ctx.idx.total_corpus_terms(), ctx.query_length};
 
-    auto comp = [](const search_result& a, const search_result& b) {
-        // comparison is reversed since we want a min-heap
-        return a.score > b.score;
-    };
-    util::fixed_heap<search_result, decltype(comp)> results{num_results, comp};
+    auto results = util::make_fixed_heap<search_result>(
+        num_results, [](const search_result& a, const search_result& b) {
+            // comparison is reversed since we want a min-heap
+            return a.score > b.score;
+        });
 
     doc_id next_doc{ctx.idx.num_docs()};
     while (ctx.cur_doc < ctx.idx.num_docs())

--- a/src/index/ranker/ranker_factory.cpp
+++ b/src/index/ranker/ranker_factory.cpp
@@ -30,6 +30,7 @@ ranker_factory::ranker_factory()
     reg<okapi_bm25>();
     reg<pivoted_length>();
     reg<kl_divergence_prf>();
+    reg<rocchio>();
 }
 
 std::unique_ptr<ranker> make_ranker(const cpptoml::table& config)
@@ -86,6 +87,7 @@ ranker_loader::ranker_loader()
     reg<okapi_bm25>();
     reg<pivoted_length>();
     reg<kl_divergence_prf>();
+    reg<rocchio>();
 }
 
 std::unique_ptr<ranker> load_ranker(std::istream& in)

--- a/src/index/ranker/ranker_factory.cpp
+++ b/src/index/ranker/ranker_factory.cpp
@@ -85,6 +85,7 @@ ranker_loader::ranker_loader()
     reg<jelinek_mercer>();
     reg<okapi_bm25>();
     reg<pivoted_length>();
+    reg<kl_divergence_prf>();
 }
 
 std::unique_ptr<ranker> load_ranker(std::istream& in)

--- a/src/index/ranker/ranker_factory.cpp
+++ b/src/index/ranker/ranker_factory.cpp
@@ -15,7 +15,10 @@ namespace index
 template <class Ranker>
 void ranker_factory::reg()
 {
-    add(Ranker::id, make_ranker<Ranker>);
+    add(Ranker::id,
+        [](const cpptoml::table& global, const cpptoml::table& local) {
+            return make_ranker<Ranker>(global, local);
+        });
 }
 
 ranker_factory::ranker_factory()
@@ -26,15 +29,46 @@ ranker_factory::ranker_factory()
     reg<jelinek_mercer>();
     reg<okapi_bm25>();
     reg<pivoted_length>();
+    reg<kl_divergence_prf>();
 }
 
 std::unique_ptr<ranker> make_ranker(const cpptoml::table& config)
 {
-    auto function = config.get_as<std::string>("method");
+    // pass a blank configuration group as the first argument to the
+    // factory method
+    static auto blank = cpptoml::make_table();
+    return make_ranker(*blank, config);
+}
+
+std::unique_ptr<ranker> make_ranker(const cpptoml::table& global,
+                                    const cpptoml::table& local)
+{
+    auto function = local.get_as<std::string>("method");
     if (!function)
         throw ranker_factory::exception{
-            "ranking-function required to construct a ranker"};
-    return ranker_factory::get().create(*function, config);
+            "method key required in [ranker] to construct a ranker"};
+
+    return ranker_factory::get().create(*function, global, local);
+}
+
+std::unique_ptr<language_model_ranker>
+make_lm_ranker(const cpptoml::table& config)
+{
+    // pass a blank configuration group as the first argument to the
+    // factory method
+    static auto blank = cpptoml::make_table();
+    return make_lm_ranker(*blank, config);
+}
+
+std::unique_ptr<language_model_ranker>
+make_lm_ranker(const cpptoml::table& global, const cpptoml::table& local)
+{
+    auto function = local.get_as<std::string>("method");
+    if (!function)
+        throw ranker_factory::exception{
+            "method key required in [ranker] to construct a ranker"};
+
+    return ranker_factory::get().create_lm(*function, global, local);
 }
 
 template <class Ranker>
@@ -58,6 +92,13 @@ std::unique_ptr<ranker> load_ranker(std::istream& in)
     std::string method;
     io::packed::read(in, method);
     return ranker_loader::get().create(method, in);
+}
+
+std::unique_ptr<language_model_ranker> load_lm_ranker(std::istream& in)
+{
+    std::string method;
+    io::packed::read(in, method);
+    return ranker_loader::get().create_lm(method, in);
 }
 }
 }

--- a/src/index/ranker/rocchio.cpp
+++ b/src/index/ranker/rocchio.cpp
@@ -1,0 +1,159 @@
+/**
+ * @file rocchio.cpp
+ * @author Chase Geigle
+ */
+
+#include "cpptoml.h"
+
+#include "meta/hashing/probe_map.h"
+#include "meta/index/forward_index.h"
+#include "meta/index/ranker/okapi_bm25.h"
+#include "meta/index/ranker/rocchio.h"
+#include "meta/index/score_data.h"
+#include "meta/io/packed.h"
+#include "meta/logging/logger.h"
+#include "meta/util/fixed_heap.h"
+#include "meta/util/shim.h"
+
+namespace meta
+{
+namespace index
+{
+
+const util::string_view rocchio::id = "rocchio";
+const constexpr float rocchio::default_alpha;
+const constexpr float rocchio::default_beta;
+const constexpr uint64_t rocchio::default_k;
+const constexpr uint64_t rocchio::default_max_terms;
+
+rocchio::rocchio(std::shared_ptr<forward_index> fwd)
+    : fwd_{std::move(fwd)},
+      initial_ranker_{make_unique<okapi_bm25>()},
+      alpha_{default_alpha},
+      beta_{default_beta},
+      k_{default_k},
+      max_terms_{default_max_terms}
+{
+    // nothing
+}
+
+rocchio::rocchio(std::shared_ptr<forward_index> fwd,
+                 std::unique_ptr<ranker>&& initial_ranker, float alpha,
+                 float beta, uint64_t k, uint64_t max_terms)
+    : fwd_{std::move(fwd)},
+      initial_ranker_{std::move(initial_ranker)},
+      alpha_{alpha},
+      beta_{beta},
+      k_{k},
+      max_terms_{max_terms}
+{
+    // nothing
+}
+
+rocchio::rocchio(std::istream& in)
+    : fwd_{[&]() {
+          auto path = io::packed::read<std::string>(in);
+          auto cfg = cpptoml::parse_file(path + "/config.toml");
+          return make_index<forward_index>(*cfg);
+      }()},
+      initial_ranker_{load_ranker(in)},
+      alpha_{io::packed::read<float>(in)},
+      beta_{io::packed::read<float>(in)},
+      k_{io::packed::read<uint64_t>(in)},
+      max_terms_{io::packed::read<uint64_t>(in)}
+{
+    // nothing
+}
+
+void rocchio::save(std::ostream& out) const
+{
+    io::packed::write(out, id);
+    io::packed::write(out, fwd_->index_name());
+    initial_ranker_->save(out);
+    io::packed::write(out, alpha_);
+    io::packed::write(out, beta_);
+    io::packed::write(out, k_);
+    io::packed::write(out, max_terms_);
+}
+
+std::vector<search_result> rocchio::rank(ranker_context& ctx,
+                                         uint64_t num_results,
+                                         const filter_function_type& filter)
+{
+    auto fb_docs = initial_ranker_->rank(ctx, k_, filter);
+
+    // compute the centroid in both count-space and tf-idf space
+    hashing::probe_map<term_id, float> term_scores;
+    hashing::probe_map<term_id, float> centroid;
+
+    score_data sd{ctx.idx, ctx.idx.avg_doc_length(), ctx.idx.num_docs(),
+                  ctx.idx.total_corpus_terms(), 1.0f};
+    sd.query_term_weight = 1.0f;
+    for (const auto& sr : fb_docs)
+    {
+        sd.d_id = sr.d_id;
+        sd.doc_size = ctx.idx.doc_size(sd.d_id);
+        sd.doc_unique_terms = ctx.idx.unique_terms(sd.d_id);
+
+        auto stream = *fwd_->stream_for(sd.d_id);
+        for (const auto& weight : stream)
+        {
+            sd.t_id = weight.first;
+            sd.doc_count = ctx.idx.doc_freq(sd.t_id);
+            sd.corpus_term_count = ctx.idx.total_num_occurences(sd.t_id);
+            sd.doc_term_count = static_cast<uint64_t>(weight.second);
+
+            auto& rnk = dynamic_cast<ranking_function&>(*initial_ranker_);
+            term_scores[sd.t_id] += rnk.score_one(sd) / k_;
+            centroid[sd.t_id] += weight.second / k_;
+        }
+    }
+
+    // extract the top max_terms_ feedback terms according to their scores
+    // in tf-idf space
+    using scored_term = std::pair<term_id, float>;
+    auto heap = util::make_fixed_heap<scored_term>(
+        max_terms_, [](const scored_term& a, const scored_term& b) {
+            return a.second > b.second;
+        });
+    for (const auto& pr : term_scores)
+    {
+        heap.emplace(pr.key(), pr.value());
+    }
+
+    // construct a new interpolated query in count-space from these top terms
+    hashing::probe_map<term_id, float> new_query;
+    for (const auto& pr : heap.extract_top())
+    {
+        new_query[pr.first] += beta_ * centroid[pr.first];
+    }
+    for (const auto& postings_ctx : ctx.postings)
+    {
+        new_query[postings_ctx.t_id] += alpha_ * postings_ctx.query_term_weight;
+    }
+
+    // construct a new ranker_context from the new query
+    ranker_context new_ctx{ctx.idx, new_query.begin(), new_query.end(), filter};
+
+    //  return ranking results based on the new query
+    return initial_ranker_->rank(new_ctx, num_results, filter);
+}
+
+template <>
+std::unique_ptr<ranker> make_ranker<rocchio>(const cpptoml::table& global,
+                                             const cpptoml::table& local)
+{
+    auto alpha = local.get_as<double>("alpha").value_or(rocchio::default_alpha);
+    auto beta = local.get_as<double>("beta").value_or(rocchio::default_beta);
+    auto k = local.get_as<uint64_t>("k").value_or(rocchio::default_k);
+    auto max_terms = local.get_as<uint64_t>("max-terms")
+                         .value_or(rocchio::default_max_terms);
+
+    auto init_cfg = local.get_table("feedback");
+    auto f_idx = make_index<forward_index>(global);
+    return make_unique<rocchio>(std::move(f_idx),
+                                make_ranker(global, *init_cfg), alpha, beta,
+                                k, max_terms);
+}
+}
+}

--- a/src/index/tools/interactive_search.cpp
+++ b/src/index/tools/interactive_search.cpp
@@ -44,7 +44,7 @@ int main(int argc, char* argv[])
     auto group = config->get_table("ranker");
     if (!group)
         throw std::runtime_error{"\"ranker\" group needed in config file!"};
-    auto ranker = index::make_ranker(*group);
+    auto ranker = index::make_ranker(*config, *group);
 
     // Find the path prefix to each document so we can print out the contents.
     std::string prefix = *config->get_as<std::string>("prefix") + "/"

--- a/src/index/tools/query_runner.cpp
+++ b/src/index/tools/query_runner.cpp
@@ -85,7 +85,7 @@ int main(int argc, char* argv[])
     auto group = config->get_table("ranker");
     if (!group)
         throw std::runtime_error{"\"ranker\" group needed in config"};
-    auto ranker = index::make_ranker(*group);
+    auto ranker = index::make_ranker(*config, *group);
 
     // Get the config group with options specific to this executable.
     auto query_group = config->get_table("query-runner");

--- a/src/index/tools/search.cpp
+++ b/src/index/tools/search.cpp
@@ -47,7 +47,7 @@ int main(int argc, char* argv[])
     auto group = config->get_table("ranker");
     if (!group)
         throw std::runtime_error{"\"ranker\" group needed in config file!"};
-    auto ranker = index::make_ranker(*group);
+    auto ranker = index::make_ranker(*config, *group);
 
     // Use UTF-8 for the default encoding unless otherwise specified.
     auto encoding = config->get_as<std::string>("encoding").value_or("utf-8");

--- a/src/lm/diff.cpp
+++ b/src/lm/diff.cpp
@@ -53,10 +53,10 @@ diff::candidates(const sentence& sent, bool use_lm /* = false */)
 {
     use_lm_ = use_lm;
     using pair_t = std::pair<sentence, double>;
-    auto comp
-        = [](const pair_t& a, const pair_t& b) { return a.second < b.second; };
 
-    util::fixed_heap<pair_t, decltype(comp)> candidates{max_cand_size_, comp};
+    auto candidates = util::make_fixed_heap<pair_t>(
+        max_cand_size_,
+        [](const pair_t& a, const pair_t& b) { return a.second < b.second; });
     seen_.clear();
     add(candidates, sent);
     step(sent, candidates, 0);

--- a/src/lm/language_model.cpp
+++ b/src/lm/language_model.cpp
@@ -95,9 +95,9 @@ language_model::top_k(const sentence& prev, size_t k) const
 {
     // this is horribly inefficient due to this LM's structure
     using pair_t = std::pair<std::string, float>;
-    auto comp
-        = [](const pair_t& a, const pair_t& b) { return a.second > b.second; };
-    util::fixed_heap<pair_t, decltype(comp)> candidates{k, comp};
+    auto candidates = util::make_fixed_heap<pair_t>(
+        k,
+        [](const pair_t& a, const pair_t& b) { return a.second > b.second; });
 
     token_list candidate{prev, vocabulary_};
     candidate.push_back(0_tid);

--- a/src/tools/top_k.cpp
+++ b/src/tools/top_k.cpp
@@ -3,19 +3,19 @@
  * @author Sean Massung
  */
 
-#include <iostream>
-#include <vector>
-#include <algorithm>
-#include <unordered_map>
-#include <string>
 #include "cpptoml.h"
-#include "meta/corpus/corpus.h"
-#include "meta/corpus/corpus_factory.h"
 #include "meta/analyzers/analyzer.h"
 #include "meta/analyzers/filters/all.h"
-#include "meta/util/progress.h"
-#include "meta/util/fixed_heap.h"
+#include "meta/corpus/corpus.h"
+#include "meta/corpus/corpus_factory.h"
 #include "meta/logging/logger.h"
+#include "meta/util/fixed_heap.h"
+#include "meta/util/progress.h"
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 using namespace meta;
 
@@ -26,7 +26,8 @@ int main(int argc, char* argv[])
         std::cerr << "Usage: " << argv[0] << " config.toml k" << std::endl;
         std::cerr << "Prints out the top k most frequent terms in the corpus "
                      "according to the filter chain specified in the config "
-                     "file." << std::endl;
+                     "file."
+                  << std::endl;
         return 1;
     }
 
@@ -57,11 +58,9 @@ int main(int argc, char* argv[])
     prog.end();
 
     using pair_t = std::pair<std::string, uint64_t>;
-    auto comp = [](const pair_t& a, const pair_t& b)
-    {
-        return a.second > b.second;
-    };
-    util::fixed_heap<pair_t, decltype(comp)> terms{k, comp};
+    auto terms = util::make_fixed_heap<pair_t>(
+        k,
+        [](const pair_t& a, const pair_t& b) { return a.second > b.second; });
     for (auto& term : counts)
         terms.emplace(term);
 

--- a/src/topics/tools/lda_topics.cpp
+++ b/src/topics/tools/lda_topics.cpp
@@ -3,8 +3,8 @@
  * @author Chase Geigle
  */
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <string>
 #include <vector>
 
@@ -44,13 +44,11 @@ int print_topics(const std::string& config_file, const std::string& filename,
         std::cout << "Topic " << topic << ":" << std::endl;
         std::cout << "-----------------------" << std::endl;
 
-        auto comp = [](const std::pair<term_id, double>& first,
-                       const std::pair<term_id, double>& second)
-        {
-            return first.second > second.second;
-        };
-        util::fixed_heap<std::pair<term_id, double>, decltype(comp)> pairs{
-            num_words, comp};
+        using scored_term = std::pair<term_id, double>;
+        auto pairs = util::make_fixed_heap<scored_term>(
+            num_words, [](const scored_term& a, const scored_term& b) {
+                return a.second > b.second;
+            });
 
         while (stream)
         {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,15 @@ ExternalProject_Add(housing
   BUILD_COMMAND ""
   INSTALL_COMMAND "")
 
+ExternalProject_Add(cranfield
+  SOURCE_DIR ${meta_BINARY_DIR}/../../data/cranfield
+  DOWNLOAD_DIR ${meta_BINARY_DIR}/../downloads
+  URL https://meta-toolkit.org/data/2016-11-10/cranfield.tar.gz
+  URL_HASH "SHA256=507b6f4f133bc1a65d140780cbd7060a3ca159410b772e5eb1e2c12b215d72b4"
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND "")
+
 # Ignore sign warnings when expanding bandit's macros.
 file(GLOB BANDIT_SOURCE_FILES *.cpp)
 set_property(SOURCE ${BANDIT_SOURCE_FILES} APPEND PROPERTY COMPILE_FLAGS

--- a/tests/ranker_regression_test.cpp
+++ b/tests/ranker_regression_test.cpp
@@ -1,0 +1,145 @@
+/**
+ * @file ranker_regression_test.cpp
+ * @author Chase Geigle
+ */
+
+#include "bandit/bandit.h"
+#include "create_config.h"
+#include "meta/corpus/document.h"
+#include "meta/index/eval/ir_eval.h"
+#include "meta/index/forward_index.h"
+#include "meta/index/ranker/all.h"
+
+using namespace bandit;
+using namespace meta;
+
+namespace
+{
+struct ret_perf
+{
+    double map;
+    double avg_ndcg;
+};
+
+ret_perf retrieval_performance(index::ranker& r, index::inverted_index& idx,
+                               const cpptoml::table& cfg)
+{
+    index::ir_eval eval{cfg};
+
+    std::ifstream queries{*cfg.get_as<std::string>("query-path")};
+    std::string line;
+
+    double cumulative_ndcg = 0.0;
+    uint64_t num_queries = 0;
+    for (query_id qid{1}; std::getline(queries, line); ++qid, ++num_queries)
+    {
+        corpus::document query;
+        query.content(line);
+        auto results = r.score(idx, query, 1);
+        eval.avg_p(results, qid, results.size());
+        cumulative_ndcg += eval.ndcg(results, qid, results.size());
+    }
+
+    ret_perf perf;
+    perf.map = eval.map();
+    perf.avg_ndcg = cumulative_ndcg / num_queries;
+    return perf;
+}
+}
+
+go_bandit([]() {
+
+    describe("[ranker regression]", []() {
+        auto cfg = tests::create_config("line");
+        cfg->insert("dataset", "cranfield");
+        cfg->insert("query-judgements",
+                    "../data/cranfield/cranfield-qrels.txt");
+        cfg->insert("index", "cranfield-idx");
+        cfg->insert("query-path", "../data/cranfield/cranfield-queries.txt");
+
+        auto anas = cfg->get_table_array("analyzers");
+        auto ana = anas->get()[0];
+        ana->insert("filter", "default-unigram-chain");
+
+        filesystem::remove_all("cranfield-idx");
+        auto idx = index::make_index<index::inverted_index>(*cfg);
+
+        it("should obtain expected performance with absolute discounting",
+           [&]() {
+               index::absolute_discount r;
+               auto perf = retrieval_performance(r, *idx, *cfg);
+               AssertThat(perf.map, IsGreaterThan(0.34));
+               AssertThat(perf.avg_ndcg, IsGreaterThan(0.22));
+           });
+
+        it("should obtain expected performance with Dirichlet prior", [&]() {
+            index::dirichlet_prior r;
+            auto perf = retrieval_performance(r, *idx, *cfg);
+            AssertThat(perf.map, IsGreaterThan(0.30));
+            AssertThat(perf.avg_ndcg, IsGreaterThan(0.21));
+        });
+
+        it("should obtain expected performance with Jelinek-Mercer", [&]() {
+            index::jelinek_mercer r;
+            auto perf = retrieval_performance(r, *idx, *cfg);
+            AssertThat(perf.map, IsGreaterThan(0.34));
+            AssertThat(perf.avg_ndcg, IsGreaterThan(0.23));
+        });
+
+        it("should obtain expected performance with Okapi BM25", [&]() {
+            index::okapi_bm25 r;
+            auto perf = retrieval_performance(r, *idx, *cfg);
+            AssertThat(perf.map, IsGreaterThan(0.33));
+            AssertThat(perf.avg_ndcg, IsGreaterThan(0.22));
+        });
+
+        it("should obtain expected performance with pivoted length", [&]() {
+            index::pivoted_length r;
+            auto perf = retrieval_performance(r, *idx, *cfg);
+            AssertThat(perf.map, IsGreaterThan(0.32));
+            AssertThat(perf.avg_ndcg, IsGreaterThan(0.21));
+        });
+
+        it("should obtain expected performance with KL-divergence PRF", [&]() {
+            index::kl_divergence_prf r{
+                index::make_index<index::forward_index>(*cfg)};
+            auto perf = retrieval_performance(r, *idx, *cfg);
+            AssertThat(perf.map, IsGreaterThan(0.33));
+            AssertThat(perf.avg_ndcg, IsGreaterThan(0.22));
+        });
+
+        it("should get better performance than Dirichlet prior when using "
+           "KL-divergence PRF",
+           [&]() {
+               index::kl_divergence_prf kl_div{
+                   index::make_index<index::forward_index>(*cfg)};
+               auto kl_perf = retrieval_performance(kl_div, *idx, *cfg);
+
+               index::dirichlet_prior dp;
+               auto dp_perf = retrieval_performance(dp, *idx, *cfg);
+
+               AssertThat(kl_perf.map, IsGreaterThanOrEqualTo(dp_perf.map));
+               AssertThat(kl_perf.avg_ndcg,
+                          IsGreaterThanOrEqualTo(dp_perf.avg_ndcg));
+           });
+
+        it("should get better performance than Jelinek-Mercer when using "
+           "KL-divergence PRF",
+           [&]() {
+               index::kl_divergence_prf kl_div{
+                   index::make_index<index::forward_index>(*cfg),
+                   make_unique<index::jelinek_mercer>()};
+               auto kl_perf = retrieval_performance(kl_div, *idx, *cfg);
+
+               index::jelinek_mercer jm;
+               auto jm_perf = retrieval_performance(jm, *idx, *cfg);
+
+               AssertThat(kl_perf.map, IsGreaterThanOrEqualTo(jm_perf.map));
+               AssertThat(kl_perf.avg_ndcg,
+                          IsGreaterThanOrEqualTo(jm_perf.avg_ndcg));
+           });
+
+        idx = nullptr;
+        filesystem::remove_all("cranfield-idx");
+    });
+});


### PR DESCRIPTION
### Main Changes
Add the KL-divergence retrieval function using pseudo-relevance feedback with the two-component mixture-model approach of Zhai and Lafferty, called `kl_divergence_prf`. This ranker internally can use any `language_model_ranker` subclass like `dirichlet_prior` or `jelinek_mercer` to perform the ranking of the feedback set and the result documents with respect to the modified query.

The EM algorithm used for the two-component mixture model is provided as the `index::feedback::unigram_mixture` free function and returns the feedback model.

This PR also breaks the ranker hierarchy into one more level. At the top we have `ranker`, which has a pure virtual function `rank()` that can be overridden to provide entirely custom ranking behavior. This is the class the KL-divergence method derives from, as we need to re-define what it means to rank documents (first retrieving a feedback set, then ranking documents with respect to an updated query).

Most of the time, however, you will want to derive from the second level `ranking_function`, which is what was called `ranker` before. This class provides a definition of `rank()` to perform document-at-a-time ranking, and expects deriving classes to instead provide `initial_score()` and `score_one()` implementations to define the scoring function used for each document. **Existing code that derived from `ranker` prior to this version of MeTA likely needs to be changed to instead derive from `ranking_function`.**

Additional functions have been added to `ranker_factory` to allow construction/loading of `language_model_ranker` subclasses (useful for the `kl_divergence_prf` implementation).

Regression tests have been added for rankers' MAP and NDCG scores. This adds a new dataset `cranfield` that contains non-binary relevance judgments to facilitate these new tests.

### Minor Changes
Adds the `util::transform_iterator` class and `util::make_transform_iterator` function for providing iterators that transform their output according to a unary function.

Adds a util::make_fixed_heap helper function to simplify the declaration of util::fixed_heap classes with lambda function comparators.