### PR TITLE
make lda_models operate on datasets instead of forward_indexes

### DIFF
--- a/include/meta/topics/lda_cvb.h
+++ b/include/meta/topics/lda_cvb.h
@@ -42,7 +42,7 @@ class lda_cvb : public lda_model
      * @param beta The hyperparameter for the Dirichlet prior over
      *  \f$\theta\f$
      */
-    lda_cvb(learn::dataset docs, std::size_t num_topics, double alpha,
+    lda_cvb(const learn::dataset& docs, std::size_t num_topics, double alpha,
             double beta);
 
     /**

--- a/include/meta/topics/lda_cvb.h
+++ b/include/meta/topics/lda_cvb.h
@@ -35,15 +35,15 @@ class lda_cvb : public lda_model
      * \f$\beta\f$ for the priors on \f$\phi\f$ (topic distributions)
      * and \f$\theta\f$ (topic proportions), respectively.
      *
-     * @param idx The index containing the documents to model
+     * @param docs Documents to model
      * @param num_topics The number of topics to infer
      * @param alpha The hyperparameter for the Dirichlet prior over
      *  \f$\phi\f$
      * @param beta The hyperparameter for the Dirichlet prior over
      *  \f$\theta\f$
      */
-    lda_cvb(std::shared_ptr<index::forward_index> idx, std::size_t num_topics,
-            double alpha, double beta);
+    lda_cvb(learn::dataset docs, std::size_t num_topics, double alpha,
+            double beta);
 
     /**
      * Destructor: virtual for potential subclassing.
@@ -68,7 +68,7 @@ class lda_cvb : public lda_model
     virtual double
     compute_term_topic_probability(term_id term, topic_id topic) const override;
 
-    virtual double compute_doc_topic_probability(doc_id doc,
+    virtual double compute_doc_topic_probability(learn::instance_id doc,
                                                  topic_id topic) const override;
 
   protected:
@@ -90,7 +90,7 @@ class lda_cvb : public lda_model
      * topic assignments for each word occurrence \f$i\f$ in document
      * \f$j\f$.
      *
-     * Indexed as gamma_[d][i]
+     * Indexed as gamma_[doc.id][i]
      */
     std::vector<std::vector<stats::multinomial<topic_id>>> gamma_;
 

--- a/include/meta/topics/lda_gibbs.h
+++ b/include/meta/topics/lda_gibbs.h
@@ -43,7 +43,7 @@ class lda_gibbs : public lda_model
      * @param beta The hyperparameter for the Dirichlet prior over
      * \f$\theta\f$
      */
-    lda_gibbs(learn::dataset docs, std::size_t num_topics, double alpha,
+    lda_gibbs(const learn::dataset& docs, std::size_t num_topics, double alpha,
               double beta);
 
     /**

--- a/include/meta/topics/lda_gibbs.h
+++ b/include/meta/topics/lda_gibbs.h
@@ -36,15 +36,15 @@ class lda_gibbs : public lda_model
      * \f$\beta\f$ for the priors on \f$\phi\f$ (topic distributions)
      * and \f$\theta\f$ (topic proportions), respectively.
      *
-     * @param idx The index that contains the documents to model
+     * @param docs Documents to model
      * @param num_topics The number of topics to infer
      * @param alpha The hyperparameter for the Dirichlet prior over
      * \f$\phi\f$
      * @param beta The hyperparameter for the Dirichlet prior over
      * \f$\theta\f$
      */
-    lda_gibbs(std::shared_ptr<index::forward_index> idx, std::size_t num_topics,
-              double alpha, double beta);
+    lda_gibbs(learn::dataset docs, std::size_t num_topics, double alpha,
+              double beta);
 
     /**
      * Destructor: virtual for potential subclassing.
@@ -82,7 +82,7 @@ class lda_gibbs : public lda_model
      * @param doc The document we are concerned with.
      * @param topic The topic we are concerned with.
      */
-    virtual double compute_doc_topic_probability(doc_id doc,
+    virtual double compute_doc_topic_probability(learn::instance_id doc,
                                                  topic_id topic) const override;
 
   protected:
@@ -97,7 +97,7 @@ class lda_gibbs : public lda_model
      * @param doc The document the term resides in
      * @return the topic sampled the given (term, doc) pair
      */
-    topic_id sample_topic(term_id term, doc_id doc);
+    topic_id sample_topic(term_id term, learn::instance_id doc);
 
     /**
      * Computes a weight proportional to \f$P(z_i = j | w, \boldsymbol{z})\f$.
@@ -109,7 +109,7 @@ class lda_gibbs : public lda_model
      * @return a weight proportional to the probability that the given term
      * in the given document belongs to the given topic
      */
-    virtual double compute_sampling_weight(term_id term, doc_id doc,
+    virtual double compute_sampling_weight(term_id term, learn::instance_id doc,
                                            topic_id topic) const;
 
     /**
@@ -136,7 +136,8 @@ class lda_gibbs : public lda_model
      * @param term The term in question
      * @param doc The document in question
      */
-    virtual void decrease_counts(topic_id topic, term_id term, doc_id doc);
+    virtual void decrease_counts(topic_id topic, term_id term,
+                                 learn::instance_id doc);
 
     /**
      * Increases all counts associated with the given topic, term, and
@@ -146,7 +147,8 @@ class lda_gibbs : public lda_model
      * @param term The term in question
      * @param doc The document in question
      */
-    virtual void increase_counts(topic_id topic, term_id term, doc_id doc);
+    virtual void increase_counts(topic_id topic, term_id term,
+                                 learn::instance_id doc);
 
     /**
      * @return \f$\log P(\mathbf{w} \mid \mathbf{z})\f$
@@ -169,7 +171,7 @@ class lda_gibbs : public lda_model
      * potentially have many different topics assigned to it, so we are
      * not using term_ids here, but our own contrived intra document term id.
      *
-     * Indexed as [doc_id][position].
+     * Indexed as [instance_id][position].
      */
     std::vector<std::vector<topic_id>> doc_word_topic_;
 

--- a/include/meta/topics/lda_model.h
+++ b/include/meta/topics/lda_model.h
@@ -140,11 +140,6 @@ class lda_model
      * The number of topics.
      */
     std::size_t num_topics_;
-
-    /**
-     * The number of total unique words.
-     */
-    std::size_t num_words_;
 };
 }
 }

--- a/include/meta/topics/lda_model.h
+++ b/include/meta/topics/lda_model.h
@@ -11,7 +11,8 @@
 #define META_TOPICS_LDA_MODEL_H_
 
 #include "meta/config.h"
-#include "meta/index/forward_index.h"
+#include "meta/learn/dataset.h"
+#include "meta/learn/instance.h"
 
 MAKE_NUMERIC_IDENTIFIER(topic_id, uint64_t)
 
@@ -42,11 +43,10 @@ class lda_model
      * Constructs an lda_model over the given set of documents and with a
      * fixed number of topics.
      *
-     * @param idx The index containing the documents to use for the model
+     * @param docs Documents to use for the model
      * @param num_topics The number of topics to find
      */
-    lda_model(std::shared_ptr<index::forward_index> idx,
-              std::size_t num_topics);
+    lda_model(learn::dataset docs, std::size_t num_topics);
 
     /**
      * Destructor. Made virtual to allow for deletion through pointer to
@@ -107,7 +107,7 @@ class lda_model
      * @param doc The document we are concerned with
      * @param topic The topic we are concerned with
      */
-    virtual double compute_doc_topic_probability(doc_id doc,
+    virtual double compute_doc_topic_probability(learn::instance_id doc,
                                                  topic_id topic) const = 0;
 
     /**
@@ -127,9 +127,14 @@ class lda_model
     lda_model(const lda_model&) = delete;
 
     /**
-     * The index containing the documents for the model.
+     * @return the total number of words in a specific document
      */
-    std::shared_ptr<index::forward_index> idx_;
+    static std::size_t doc_size(const learn::instance& inst);
+
+    /**
+     * Documents to run the topic modeling on.
+     */
+    learn::dataset docs_;
 
     /**
      * The number of topics.

--- a/include/meta/topics/lda_model.h
+++ b/include/meta/topics/lda_model.h
@@ -46,7 +46,7 @@ class lda_model
      * @param docs Documents to use for the model
      * @param num_topics The number of topics to find
      */
-    lda_model(learn::dataset docs, std::size_t num_topics);
+    lda_model(const learn::dataset& docs, std::size_t num_topics);
 
     /**
      * Destructor. Made virtual to allow for deletion through pointer to
@@ -134,7 +134,7 @@ class lda_model
     /**
      * Documents to run the topic modeling on.
      */
-    learn::dataset docs_;
+    const learn::dataset& docs_;
 
     /**
      * The number of topics.

--- a/include/meta/topics/lda_scvb.h
+++ b/include/meta/topics/lda_scvb.h
@@ -12,6 +12,7 @@
 
 #include "meta/config.h"
 #include "meta/topics/lda_model.h"
+#include "meta/learn/dataset_view.h"
 
 namespace meta
 {
@@ -35,7 +36,7 @@ class lda_scvb : public lda_model
      * and \f$\theta\f$ (topic proportions), respectively. Adheres to a
      * step-size schedule of \f$\frac{s}{(\tau + t)^\kappa}\f$.
      *
-     * @param idx The index containing the documents to model
+     * @param docs Documents to model
      * @param num_topics The number of topics to infer
      * @param alpha The hyperparameter for the Dirichlet prior over
      *  \f$\phi\f$
@@ -44,8 +45,8 @@ class lda_scvb : public lda_model
      * @param minibatch_size The number of documents to consider in a
      * minibatch
      */
-    lda_scvb(std::shared_ptr<index::forward_index> idx, std::size_t num_topics,
-             double alpha, double beta, uint64_t minibatch_size = 100);
+    lda_scvb(learn::dataset docs, std::size_t num_topics, double alpha,
+             double beta, uint64_t minibatch_size = 100);
 
     /**
      * Destructor: virtual for potential subclassing.
@@ -67,23 +68,26 @@ class lda_scvb : public lda_model
     virtual double
     compute_term_topic_probability(term_id term, topic_id topic) const override;
 
-    virtual double compute_doc_topic_probability(doc_id doc,
+    virtual double compute_doc_topic_probability(learn::instance_id doc,
                                                  topic_id topic) const override;
 
   private:
     /**
      * Initialize the model with random parameters.
-     *
-     * @param gen The random number generator to use.
      */
-    void initialize(std::mt19937& gen);
+    void initialize();
 
     /**
      * Performs one iteration (e.g., one minibatch) of the inference algorithm.
      * @param iter The iteration number
-     * @param docs Contains the minibatch in indexes [0, minibatch_size_]
      */
-    void perform_iteration(uint64_t iter, const std::vector<doc_id>& docs);
+    void perform_iteration(uint64_t iter);
+
+    /**
+     * View of underlying documents that can efficiently be shuffled for each
+     * minibatch.
+     */
+    learn::dataset_view docs_view_;
 
     /**
      * Contains the expected counts for each word being assigned a given
@@ -95,7 +99,7 @@ class lda_scvb : public lda_model
     /**
      * Contains the expected counts for each topic being assigned in a
      * given document. Indexed as `doc_topic_count_[d][k]` where `d` is a
-     * `doc_id` and `k` is a `topic_id`.
+     * `instance_id` and `k` is a `topic_id`.
      */
     std::vector<std::vector<double>> doc_topic_count_;
 
@@ -105,6 +109,12 @@ class lda_scvb : public lda_model
      * included here for performance reasons.
      */
     std::vector<double> topic_count_;
+
+    /**
+     * Cache doc_size calculation so it doesn't need to be called multiple times
+     * per document per iteration.
+     */
+    std::vector<double> doc_sizes_;
 
     /// The hyperparameter on \f$\theta\f$, the topic proportions
     const double alpha_;

--- a/include/meta/topics/lda_scvb.h
+++ b/include/meta/topics/lda_scvb.h
@@ -45,7 +45,7 @@ class lda_scvb : public lda_model
      * @param minibatch_size The number of documents to consider in a
      * minibatch
      */
-    lda_scvb(learn::dataset docs, std::size_t num_topics, double alpha,
+    lda_scvb(const learn::dataset& docs, std::size_t num_topics, double alpha,
              double beta, uint64_t minibatch_size = 100);
 
     /**

--- a/include/meta/topics/parallel_lda_gibbs.h
+++ b/include/meta/topics/parallel_lda_gibbs.h
@@ -56,12 +56,12 @@ class parallel_lda_gibbs : public lda_gibbs
     virtual void perform_iteration(uint64_t iter, bool init = false) override;
 
     virtual void decrease_counts(topic_id topic, term_id term,
-                                 doc_id doc) override;
+                                 learn::instance_id doc) override;
 
     virtual void increase_counts(topic_id topic, term_id term,
-                                 doc_id doc) override;
+                                 learn::instance_id doc) override;
 
-    virtual double compute_sampling_weight(term_id term, doc_id doc,
+    virtual double compute_sampling_weight(term_id term, learn::instance_id doc,
                                            topic_id topic) const override;
 
     /**

--- a/src/topics/lda_cvb.cpp
+++ b/src/topics/lda_cvb.cpp
@@ -13,9 +13,9 @@ namespace meta
 namespace topics
 {
 
-lda_cvb::lda_cvb(learn::dataset docs, std::size_t num_topics, double alpha,
-                 double beta)
-    : lda_model{std::move(docs), num_topics}
+lda_cvb::lda_cvb(const learn::dataset& docs, std::size_t num_topics,
+                 double alpha, double beta)
+    : lda_model{docs, num_topics}
 {
     gamma_.resize(docs_.size());
 

--- a/src/topics/lda_cvb.cpp
+++ b/src/topics/lda_cvb.cpp
@@ -4,7 +4,6 @@
  */
 
 #include "meta/topics/lda_cvb.h"
-#include "meta/index/postings_data.h"
 #include "meta/logging/logger.h"
 #include "meta/util/progress.h"
 #include <random>
@@ -14,19 +13,19 @@ namespace meta
 namespace topics
 {
 
-lda_cvb::lda_cvb(std::shared_ptr<index::forward_index> idx,
-                 std::size_t num_topics, double alpha, double beta)
-    : lda_model{std::move(idx), num_topics}
+lda_cvb::lda_cvb(learn::dataset docs, std::size_t num_topics, double alpha,
+                 double beta)
+    : lda_model{std::move(docs), num_topics}
 {
-    gamma_.resize(idx_->num_docs());
+    gamma_.resize(docs_.size());
 
     // each theta_ is a multinomial over topics with a symmetric
     // Dirichlet(\alpha) prior
-    theta_.reserve(idx_->num_docs());
-    for (doc_id doc{0}; doc < idx_->num_docs(); ++doc)
+    theta_.reserve(docs_.size());
+    for (const auto& doc : docs_)
     {
         theta_.emplace_back(stats::dirichlet<topic_id>{alpha, num_topics_});
-        gamma_[doc].resize(idx_->doc_size(doc));
+        gamma_[doc.id].resize(doc_size(doc));
     }
 
     // each phi_ is a multinomial over terms with a symmetric
@@ -34,7 +33,7 @@ lda_cvb::lda_cvb(std::shared_ptr<index::forward_index> idx,
     phi_.reserve(num_topics_);
     for (topic_id topic{0}; topic < num_topics_; ++topic)
         phi_.emplace_back(
-            stats::dirichlet<term_id>{beta, idx_->unique_terms()});
+            stats::dirichlet<term_id>{beta, docs_.total_features()});
 }
 
 void lda_cvb::run(uint64_t num_iters, double convergence)
@@ -65,30 +64,30 @@ void lda_cvb::initialize()
 {
     std::random_device rdev;
     std::mt19937 rng(rdev());
-    printing::progress progress{"Initialization: ", idx_->num_docs()};
+    printing::progress progress{"Initialization: ", docs_.size()};
 
-    for (doc_id d{0}; d < idx_->num_docs(); ++d)
+    for (const auto& doc : docs_)
     {
-        progress(d);
+        progress(doc.id);
 
         uint64_t i = 0; // i here is the inter-document term id, since we need
                         // to handle each word occurrence separately
-        for (auto& freq : idx_->search_primary(d)->counts())
+        for (const auto& freq : doc.weights)
         {
             for (uint64_t count = 0; count < freq.second; ++count)
             {
                 // create random gamma distributions
                 for (topic_id k{0}; k < num_topics_; ++k)
                 {
-                    gamma_[d][i].increment(k, rng());
+                    gamma_[doc.id][i].increment(k, rng());
                 }
 
                 // contribute expected counts to phi_ and theta_
                 for (topic_id k{0}; k < num_topics_; ++k)
                 {
-                    auto prob = gamma_[d][i].probability(k);
+                    auto prob = gamma_[doc.id][i].probability(k);
                     phi_[k].increment(freq.first, prob);
-                    theta_[d].increment(k, prob);
+                    theta_[doc.id].increment(k, prob);
                 }
 
                 i += 1;
@@ -100,38 +99,38 @@ void lda_cvb::initialize()
 double lda_cvb::perform_iteration(uint64_t iter)
 {
     printing::progress progress{"Iteration " + std::to_string(iter) + ": ",
-                                idx_->num_docs()};
+                                docs_.size()};
     progress.print_endline(false);
     double max_change = 0;
-    for (doc_id d{0}; d < idx_->num_docs(); ++d)
+    for (const auto& doc : docs_)
     {
-        progress(d);
+        progress(doc.id);
 
         uint64_t i = 0; // term number within document---constructed
                         // so that each occurrence of the same term
                         // can still be assigned a different topic
-        for (auto& freq : idx_->search_primary(d)->counts())
+        for (const auto& freq : doc.weights)
         {
             for (uint64_t count = 0; count < freq.second; ++count)
             {
-                auto old_gamma = gamma_[d][i];
+                auto old_gamma = gamma_[doc.id][i];
                 for (topic_id k{0}; k < num_topics_; ++k)
                 {
                     // remove this word occurrence from the distributions
-                    auto prob = gamma_[d][i].probability(k);
+                    auto prob = gamma_[doc.id][i].probability(k);
                     phi_[k].decrement(freq.first, prob);
-                    theta_[d].decrement(k, prob);
+                    theta_[doc.id].decrement(k, prob);
                 }
 
-                gamma_[d][i].clear();
+                gamma_[doc.id][i].clear();
                 for (topic_id k{0}; k < num_topics_; ++k)
                 {
                     // "sample" the next topic: we are doing
                     // soft-assignment here so we actually just compute the
                     // probability of this topic
                     auto weight = phi_[k].probability(freq.first)
-                                  * theta_[d].probability(k);
-                    gamma_[d][i].increment(k, weight);
+                                  * theta_[doc.id].probability(k);
+                    gamma_[doc.id][i].increment(k, weight);
                 }
 
                 double delta = 0;
@@ -139,9 +138,9 @@ double lda_cvb::perform_iteration(uint64_t iter)
                 {
                     // recontribute expected counts, keep track of gamma
                     // changes for convergence
-                    auto prob = gamma_[d][i].probability(k);
+                    auto prob = gamma_[doc.id][i].probability(k);
                     phi_[k].increment(freq.first, prob);
-                    theta_[d].increment(k, prob);
+                    theta_[doc.id].increment(k, prob);
                     delta += std::abs(prob - old_gamma.probability(k));
                 }
                 max_change = std::max(max_change, delta);
@@ -158,7 +157,8 @@ double lda_cvb::compute_term_topic_probability(term_id term,
     return phi_[topic].probability(term);
 }
 
-double lda_cvb::compute_doc_topic_probability(doc_id doc, topic_id topic) const
+double lda_cvb::compute_doc_topic_probability(learn::instance_id doc,
+                                              topic_id topic) const
 {
     return theta_[doc].probability(topic);
 }

--- a/src/topics/lda_gibbs.cpp
+++ b/src/topics/lda_gibbs.cpp
@@ -14,9 +14,9 @@ namespace meta
 namespace topics
 {
 
-lda_gibbs::lda_gibbs(learn::dataset docs, std::size_t num_topics, double alpha,
-                     double beta)
-    : lda_model{std::move(docs), num_topics}
+lda_gibbs::lda_gibbs(const learn::dataset& docs, std::size_t num_topics,
+                     double alpha, double beta)
+    : lda_model{docs, num_topics}
 {
     doc_word_topic_.resize(docs_.size());
 

--- a/src/topics/lda_gibbs.cpp
+++ b/src/topics/lda_gibbs.cpp
@@ -173,7 +173,7 @@ double lda_gibbs::corpus_log_likelihood() const
 
     for (topic_id j{0}; j < num_topics_; ++j)
     {
-        for (term_id t{0}; t < num_words_; ++t)
+        for (term_id t{0}; t < docs_.total_features(); ++t)
         {
             likelihood += std::lgamma(phi_[j].counts(t))
                           - std::lgamma(phi_[j].prior().pseudo_counts(t));

--- a/src/topics/lda_gibbs.cpp
+++ b/src/topics/lda_gibbs.cpp
@@ -3,32 +3,30 @@
  * @author Chase Geigle
  */
 
+#include "meta/topics/lda_gibbs.h"
+#include "meta/logging/logger.h"
+#include "meta/util/progress.h"
 #include <algorithm>
 #include <cmath>
-
-#include "meta/index/postings_data.h"
-#include "meta/logging/logger.h"
-#include "meta/topics/lda_gibbs.h"
-#include "meta/util/progress.h"
 
 namespace meta
 {
 namespace topics
 {
 
-lda_gibbs::lda_gibbs(std::shared_ptr<index::forward_index> idx,
-                     std::size_t num_topics, double alpha, double beta)
-    : lda_model{std::move(idx), num_topics}
+lda_gibbs::lda_gibbs(learn::dataset docs, std::size_t num_topics, double alpha,
+                     double beta)
+    : lda_model{std::move(docs), num_topics}
 {
-    doc_word_topic_.resize(idx_->num_docs());
+    doc_word_topic_.resize(docs_.size());
 
     // each theta_ is a multinomial over topics with a symmetric
     // Dirichlet(\alpha) prior
-    theta_.reserve(idx_->num_docs());
-    for (doc_id doc{0}; doc < idx_->num_docs(); ++doc)
+    theta_.reserve(docs_.size());
+    for (const auto& doc : docs_)
     {
         theta_.emplace_back(stats::dirichlet<topic_id>{alpha, num_topics_});
-        doc_word_topic_[doc].resize(idx_->doc_size(doc));
+        doc_word_topic_[doc.id].resize(doc_size(doc));
     }
 
     // each phi_ is a multinomial over terms with a symmetric
@@ -36,7 +34,7 @@ lda_gibbs::lda_gibbs(std::shared_ptr<index::forward_index> idx,
     phi_.reserve(num_topics_);
     for (topic_id topic{0}; topic < num_topics_; ++topic)
         phi_.emplace_back(
-            stats::dirichlet<term_id>{beta, idx_->unique_terms()});
+            stats::dirichlet<term_id>{beta, docs_.total_features()});
 
     std::random_device dev;
     rng_.seed(dev());
@@ -71,14 +69,15 @@ void lda_gibbs::run(uint64_t num_iters, double convergence /* = 1e-6 */)
         if (ratio <= convergence)
         {
             LOG(progress) << "Found convergence after " << i + 1
-                          << " iterations!\n" << ENDLG;
+                          << " iterations!\n"
+                          << ENDLG;
             break;
         }
     }
     LOG(info) << "Finished maximum iterations, or found convergence!" << ENDLG;
 }
 
-topic_id lda_gibbs::sample_topic(term_id term, doc_id doc)
+topic_id lda_gibbs::sample_topic(term_id term, learn::instance_id doc)
 {
     stats::multinomial<topic_id> full_conditional;
     for (topic_id topic{0}; topic < num_topics_; ++topic)
@@ -89,7 +88,7 @@ topic_id lda_gibbs::sample_topic(term_id term, doc_id doc)
     return full_conditional(rng_);
 }
 
-double lda_gibbs::compute_sampling_weight(term_id term, doc_id doc,
+double lda_gibbs::compute_sampling_weight(term_id term, learn::instance_id doc,
                                           topic_id topic) const
 {
     return compute_term_topic_probability(term, topic)
@@ -102,7 +101,7 @@ double lda_gibbs::compute_term_topic_probability(term_id term,
     return phi_[topic].probability(term);
 }
 
-double lda_gibbs::compute_doc_topic_probability(doc_id doc,
+double lda_gibbs::compute_doc_topic_probability(learn::instance_id doc,
                                                 topic_id topic) const
 {
     return theta_[doc].probability(topic);
@@ -120,43 +119,45 @@ void lda_gibbs::perform_iteration(uint64_t iter, bool init /* = false */)
         str = "Initialization: ";
     else
         str = "Iteration " + std::to_string(iter) + ": ";
-    printing::progress progress{str, idx_->num_docs()};
+    printing::progress progress{str, docs_.size()};
     progress.print_endline(false);
-    for (const auto& i : idx_->docs())
+    for (const auto& doc : docs_)
     {
-        progress(i);
+        progress(doc.id);
         uint64_t n = 0; // term number within document---constructed
                         // so that each occurrence of the same term
                         // can still be assigned a different topic
-        for (const auto& freq : idx_->search_primary(i)->counts())
+        for (const auto& freq : doc.weights)
         {
             for (uint64_t j = 0; j < freq.second; ++j)
             {
-                auto old_topic = doc_word_topic_[i][n];
+                auto old_topic = doc_word_topic_[doc.id][n];
                 // don't include current topic assignment in
                 // probability calculation
                 if (!init)
-                    decrease_counts(old_topic, freq.first, i);
+                    decrease_counts(old_topic, freq.first, doc.id);
 
                 // sample a new topic assignment
-                auto topic = sample_topic(freq.first, i);
-                doc_word_topic_[i][n] = topic;
+                auto topic = sample_topic(freq.first, doc.id);
+                doc_word_topic_[doc.id][n] = topic;
 
                 // increase counts
-                increase_counts(topic, freq.first, i);
+                increase_counts(topic, freq.first, doc.id);
                 n += 1;
             }
         }
     }
 }
 
-void lda_gibbs::decrease_counts(topic_id topic, term_id term, doc_id doc)
+void lda_gibbs::decrease_counts(topic_id topic, term_id term,
+                                learn::instance_id doc)
 {
     phi_[topic].decrement(term, 1);
     theta_[doc].decrement(topic, 1);
 }
 
-void lda_gibbs::increase_counts(topic_id topic, term_id term, doc_id doc)
+void lda_gibbs::increase_counts(topic_id topic, term_id term,
+                                learn::instance_id doc)
 {
     phi_[topic].increment(term, 1);
     theta_[doc].increment(topic, 1);

--- a/src/topics/lda_model.cpp
+++ b/src/topics/lda_model.cpp
@@ -11,7 +11,7 @@ namespace topics
 {
 
 lda_model::lda_model(const learn::dataset& docs, std::size_t num_topics)
-    : docs_{docs}, num_topics_{num_topics}
+    : docs_(docs), num_topics_{num_topics}
 {
     /* nothing */
 }

--- a/src/topics/lda_model.cpp
+++ b/src/topics/lda_model.cpp
@@ -83,9 +83,10 @@ uint64_t lda_model::num_topics() const
 std::size_t lda_model::doc_size(const learn::instance& inst)
 {
     using pair_t = std::pair<learn::feature_id, double>;
-    return std::accumulate(
+    auto sum = std::accumulate(
         inst.weights.begin(), inst.weights.end(), 0.0,
         [](std::size_t amt, const pair_t& in) { return in.second + amt; });
+    return static_cast<uint64_t>(sum);
 }
 }
 }

--- a/src/topics/lda_model.cpp
+++ b/src/topics/lda_model.cpp
@@ -10,10 +10,8 @@ namespace meta
 namespace topics
 {
 
-lda_model::lda_model(learn::dataset docs, std::size_t num_topics)
-    : docs_{std::move(docs)},
-      num_topics_{num_topics},
-      num_words_(docs_.total_features())
+lda_model::lda_model(const learn::dataset& docs, std::size_t num_topics)
+    : docs_{docs}, num_topics_{num_topics}, num_words_(docs_.total_features())
 {
     /* nothing */
 }

--- a/src/topics/lda_model.cpp
+++ b/src/topics/lda_model.cpp
@@ -10,11 +10,10 @@ namespace meta
 namespace topics
 {
 
-lda_model::lda_model(std::shared_ptr<index::forward_index> idx,
-                     std::size_t num_topics)
-    : idx_{std::move(idx)},
+lda_model::lda_model(learn::dataset docs, std::size_t num_topics)
+    : docs_{std::move(docs)},
       num_topics_{num_topics},
-      num_words_(idx_->unique_terms())
+      num_words_(docs_.total_features())
 {
     /* nothing */
 }
@@ -22,13 +21,13 @@ lda_model::lda_model(std::shared_ptr<index::forward_index> idx,
 void lda_model::save_doc_topic_distributions(const std::string& filename) const
 {
     std::ofstream file{filename};
-    for (const auto& d_id : idx_->docs())
+    for (const auto& doc : docs_)
     {
-        file << d_id << "\t";
+        file << doc.id << "\t";
         double sum = 0;
         for (topic_id j{0}; j < num_topics_; ++j)
         {
-            double prob = compute_doc_topic_probability(d_id, j);
+            double prob = compute_doc_topic_probability(doc.id, j);
             if (prob > 0)
                 file << j << ":" << prob << "\t";
             sum += prob;
@@ -45,8 +44,8 @@ void lda_model::save_topic_term_distributions(const std::string& filename) const
 
     // first, compute the denominators for each term's normalized score
     std::vector<double> denoms;
-    denoms.reserve(idx_->unique_terms());
-    for (term_id t_id{0}; t_id < idx_->unique_terms(); ++t_id)
+    denoms.reserve(docs_.total_features());
+    for (term_id t_id{0}; t_id < docs_.total_features(); ++t_id)
     {
         double denom = 1.0;
         for (topic_id j{0}; j < num_topics_; ++j)
@@ -59,7 +58,7 @@ void lda_model::save_topic_term_distributions(const std::string& filename) const
     for (topic_id j{0}; j < num_topics_; ++j)
     {
         file << j << "\t";
-        for (term_id t_id{0}; t_id < idx_->unique_terms(); ++t_id)
+        for (term_id t_id{0}; t_id < docs_.total_features(); ++t_id)
         {
             double prob = compute_term_topic_probability(t_id, j);
             double norm_prob = prob * std::log(prob / denoms[t_id]);
@@ -79,6 +78,14 @@ void lda_model::save(const std::string& prefix) const
 uint64_t lda_model::num_topics() const
 {
     return num_topics_;
+}
+
+std::size_t lda_model::doc_size(const learn::instance& inst)
+{
+    using pair_t = std::pair<learn::feature_id, double>;
+    return std::accumulate(
+        inst.weights.begin(), inst.weights.end(), 0.0,
+        [](std::size_t amt, const pair_t& in) { return in.second + amt; });
 }
 }
 }

--- a/src/topics/lda_model.cpp
+++ b/src/topics/lda_model.cpp
@@ -11,7 +11,7 @@ namespace topics
 {
 
 lda_model::lda_model(const learn::dataset& docs, std::size_t num_topics)
-    : docs_{docs}, num_topics_{num_topics}, num_words_(docs_.total_features())
+    : docs_{docs}, num_topics_{num_topics}
 {
     /* nothing */
 }

--- a/src/topics/lda_scvb.cpp
+++ b/src/topics/lda_scvb.cpp
@@ -14,7 +14,7 @@ namespace topics
 
 lda_scvb::lda_scvb(const learn::dataset& docs, std::size_t num_topics,
                    double alpha, double beta, uint64_t minibatch_size)
-    : lda_model{std::move(docs), num_topics},
+    : lda_model{docs, num_topics},
       docs_view_{docs_},
       alpha_{alpha},
       beta_{beta},
@@ -100,7 +100,7 @@ void lda_scvb::perform_iteration(uint64_t iter)
             for (topic_id k{0}; k < num_topics_; ++k)
             {
                 gamma[k] = (topic_term_count_[k][freq.first] + beta_)
-                           / (topic_count_[k] + num_words_ * beta_)
+                           / (topic_count_[k] + docs_.total_features() * beta_)
                            * (doc_topic_count_[doc.id][k] + alpha_);
                 sum += gamma[k];
             }
@@ -123,7 +123,7 @@ void lda_scvb::perform_iteration(uint64_t iter)
             for (topic_id k{0}; k < num_topics_; ++k)
             {
                 gamma[k] = (topic_term_count_[k][freq.first] + beta_)
-                           / (topic_count_[k] + num_words_ * beta_)
+                           / (topic_count_[k] + docs_.total_features() * beta_)
                            * (doc_topic_count_[doc.id][k] + alpha_);
                 sum += gamma[k];
             }
@@ -160,7 +160,7 @@ void lda_scvb::perform_iteration(uint64_t iter)
     // it may...
     for (topic_id k{0}; k < num_topics_; ++k)
     {
-        for (term_id i{0}; i < num_words_; ++i)
+        for (term_id i{0}; i < docs_.total_features(); ++i)
         {
             topic_term_count_[k][i]
                 = (1 - lr) * topic_term_count_[k][i]
@@ -175,7 +175,7 @@ double lda_scvb::compute_term_topic_probability(term_id term,
                                                 topic_id topic) const
 {
     return (topic_term_count_.at(topic).at(term) + beta_)
-           / (topic_count_.at(topic) + num_words_ * beta_);
+           / (topic_count_.at(topic) + docs_.total_features() * beta_);
 }
 
 double lda_scvb::compute_doc_topic_probability(learn::instance_id doc,

--- a/src/topics/lda_scvb.cpp
+++ b/src/topics/lda_scvb.cpp
@@ -18,7 +18,8 @@ lda_scvb::lda_scvb(learn::dataset docs, std::size_t num_topics, double alpha,
       docs_view_{docs_},
       alpha_{alpha},
       beta_{beta},
-      minibatch_size_{std::min(minibatch_size, docs_.size())}
+      minibatch_size_{
+          std::min(minibatch_size, static_cast<uint64_t>(docs_.size()))}
 {
     // nothing
 }

--- a/src/topics/lda_scvb.cpp
+++ b/src/topics/lda_scvb.cpp
@@ -3,56 +3,56 @@
  * @author Chase Geigle
  */
 
-#include <random>
-#include "meta/index/postings_data.h"
 #include "meta/topics/lda_scvb.h"
 #include "meta/util/progress.h"
+#include <random>
 
 namespace meta
 {
 namespace topics
 {
 
-lda_scvb::lda_scvb(std::shared_ptr<index::forward_index> idx,
-                   std::size_t num_topics, double alpha, double beta,
-                   uint64_t minibatch_size)
-    : lda_model{std::move(idx), num_topics},
+lda_scvb::lda_scvb(learn::dataset docs, std::size_t num_topics, double alpha,
+                   double beta, uint64_t minibatch_size)
+    : lda_model{std::move(docs), num_topics},
+      docs_view_{docs_},
       alpha_{alpha},
       beta_{beta},
-      minibatch_size_{std::min(minibatch_size, idx_->num_docs())}
+      minibatch_size_{std::min(minibatch_size, docs_.size())}
 {
     // nothing
 }
 
 void lda_scvb::run(uint64_t num_iters, double)
 {
-    std::mt19937 gen{std::random_device{}()};
-    initialize(gen);
-    auto docs = idx_->docs();
+    initialize();
     for (uint64_t iter = 0; iter < num_iters; ++iter)
     {
-        std::shuffle(docs.begin(), docs.end(), gen);
-        perform_iteration(iter + 1, docs);
+        docs_view_.shuffle();
+        perform_iteration(iter + 1);
     }
 }
 
-void lda_scvb::initialize(std::mt19937& rng)
+void lda_scvb::initialize()
 {
     // TODO: Don't actually iterate through whole dataset here
-    doc_topic_count_.resize(idx_->num_docs());
+    doc_topic_count_.resize(docs_.size());
     topic_term_count_.resize(num_topics_);
     for (auto& v : topic_term_count_)
-        v.resize(idx_->unique_terms());
+        v.resize(docs_.total_features());
     topic_count_.resize(num_topics_);
+    doc_sizes_.resize(docs_.size());
 
-    printing::progress progress{" > Initialization: ", idx_->num_docs()};
-    for (doc_id d{0}; d < idx_->num_docs(); ++d)
+    std::mt19937 rng{std::random_device{}()};
+    printing::progress progress{" > Initialization: ", docs_.size()};
+    for (const auto& doc : docs_)
     {
-        progress(d);
+        progress(doc.id);
 
-        doc_topic_count_[d].resize(num_topics_);
+        doc_sizes_[doc.id] = doc_size(doc);
+        doc_topic_count_[doc.id].resize(num_topics_);
 
-        for (auto& freq : idx_->search_primary(d)->counts())
+        for (const auto& freq : doc.weights)
         {
             double sum = 0;
             std::vector<double> gamma(num_topics_);
@@ -66,14 +66,14 @@ void lda_scvb::initialize(std::mt19937& rng)
             {
                 gamma[k] = gamma[k] * freq.second / sum;
                 topic_term_count_[k][freq.first] += gamma[k];
-                doc_topic_count_[d][k] += gamma[k];
+                doc_topic_count_[doc.id][k] += gamma[k];
                 topic_count_[k] += gamma[k];
             }
         }
     }
 }
 
-void lda_scvb::perform_iteration(uint64_t iter, const std::vector<doc_id>& docs)
+void lda_scvb::perform_iteration(uint64_t iter)
 {
     printing::progress progress{"Minibatch " + std::to_string(iter) + ": ",
                                 minibatch_size_};
@@ -83,20 +83,24 @@ void lda_scvb::perform_iteration(uint64_t iter, const std::vector<doc_id>& docs)
     std::vector<double> batch_topic_count_(num_topics_, 0.0);
     std::vector<double> gamma(num_topics_);
 
-    for (uint64_t j = 0; j < minibatch_size_; ++j)
+    uint64_t j = 0;
+    for (const auto& doc : docs_view_)
     {
+        if (j++ >= minibatch_size_)
+            break;
+
         progress(j);
-        auto d = docs[j];
+
         // burn-in phase
         double t = 0;
-        for (const auto& freq : idx_->search_primary(d)->counts())
+        for (const auto& freq : doc.weights)
         {
             double sum = 0;
             for (topic_id k{0}; k < num_topics_; ++k)
             {
                 gamma[k] = (topic_term_count_[k][freq.first] + beta_)
                            / (topic_count_[k] + num_words_ * beta_)
-                           * (doc_topic_count_[d][k] + alpha_);
+                           * (doc_topic_count_[doc.id][k] + alpha_);
                 sum += gamma[k];
             }
             for (topic_id k{0}; k < num_topics_; ++k)
@@ -104,22 +108,22 @@ void lda_scvb::perform_iteration(uint64_t iter, const std::vector<doc_id>& docs)
                 gamma[k] /= sum;
                 auto lr = 1.0 / std::pow(10 + t, 0.9);
                 auto weight = std::pow(1 - lr, freq.second);
-                doc_topic_count_[d][k]
-                    = weight * doc_topic_count_[d][k]
-                      + (1 - weight) * idx_->doc_size(d) * gamma[k];
+                doc_topic_count_[doc.id][k]
+                    = weight * doc_topic_count_[doc.id][k]
+                      + (1 - weight) * doc_sizes_.at(doc.id) * gamma[k];
             }
             t += freq.second;
         }
 
         // normal phase
-        for (const auto& freq : idx_->search_primary(d)->counts())
+        for (const auto& freq : doc.weights)
         {
             double sum = 0;
             for (topic_id k{0}; k < num_topics_; ++k)
             {
                 gamma[k] = (topic_term_count_[k][freq.first] + beta_)
                            / (topic_count_[k] + num_words_ * beta_)
-                           * (doc_topic_count_[d][k] + alpha_);
+                           * (doc_topic_count_[doc.id][k] + alpha_);
                 sum += gamma[k];
             }
             for (topic_id k{0}; k < num_topics_; ++k)
@@ -131,14 +135,14 @@ void lda_scvb::perform_iteration(uint64_t iter, const std::vector<doc_id>& docs)
                 auto lr = 1.0 / std::pow(10 + t, 0.9);
                 auto weight = std::pow(1 - lr, freq.second);
 
-                doc_topic_count_[d][k]
-                    = weight * doc_topic_count_[d][k]
-                      + (1 - weight) * idx_->doc_size(d) * gamma[k];
+                doc_topic_count_[doc.id][k]
+                    = weight * doc_topic_count_[doc.id][k]
+                      + (1 - weight) * doc_sizes_.at(doc.id) * gamma[k];
 
                 batch_topic_term_count_[k][freq.first]
-                    += idx_->num_docs() * gamma[k];
+                    += docs_.size() * gamma[k];
 
-                batch_topic_count_[k] += idx_->num_docs() * gamma[k];
+                batch_topic_count_[k] += docs_.size() * gamma[k];
             }
             t += freq.second;
         }
@@ -173,10 +177,11 @@ double lda_scvb::compute_term_topic_probability(term_id term,
            / (topic_count_.at(topic) + num_words_ * beta_);
 }
 
-double lda_scvb::compute_doc_topic_probability(doc_id doc, topic_id topic) const
+double lda_scvb::compute_doc_topic_probability(learn::instance_id doc,
+                                               topic_id topic) const
 {
     return (doc_topic_count_.at(doc).at(topic) + alpha_)
-           / (idx_->doc_size(doc) + num_topics_ * alpha_);
+           / (doc_sizes_.at(doc) + num_topics_ * alpha_);
 }
 }
 }

--- a/src/topics/lda_scvb.cpp
+++ b/src/topics/lda_scvb.cpp
@@ -12,8 +12,8 @@ namespace meta
 namespace topics
 {
 
-lda_scvb::lda_scvb(learn::dataset docs, std::size_t num_topics, double alpha,
-                   double beta, uint64_t minibatch_size)
+lda_scvb::lda_scvb(const learn::dataset& docs, std::size_t num_topics,
+                   double alpha, double beta, uint64_t minibatch_size)
     : lda_model{std::move(docs), num_topics},
       docs_view_{docs_},
       alpha_{alpha},

--- a/src/topics/parallel_lda_gibbs.cpp
+++ b/src/topics/parallel_lda_gibbs.cpp
@@ -3,12 +3,11 @@
  * @author Chase Geigle
  */
 
-#include "meta/index/postings_data.h"
+#include "meta/topics/parallel_lda_gibbs.h"
+#include "meta/learn/instance.h"
 #include "meta/logging/logger.h"
 #include "meta/parallel/parallel_for.h"
-#include "meta/topics/parallel_lda_gibbs.h"
 #include "meta/util/progress.h"
-#include "meta/util/range.h"
 
 namespace meta
 {
@@ -30,10 +29,8 @@ void parallel_lda_gibbs::perform_iteration(uint64_t iter,
         str = "Initialization: ";
     else
         str = "Iteration " + std::to_string(iter) + ": ";
-    printing::progress progress{str, idx_->num_docs()};
+    printing::progress progress{str, docs_.size()};
     progress.print_endline(false);
-
-    auto range = util::range<doc_id>(doc_id{0}, doc_id{idx_->num_docs() - 1});
 
     // clear out diffs
     for (auto& phis : phi_diffs_)
@@ -42,35 +39,35 @@ void parallel_lda_gibbs::perform_iteration(uint64_t iter,
 
     std::mutex mutex;
     uint64_t assigned = 0;
-    parallel::parallel_for(range.begin(), range.end(), pool_, [&](doc_id i)
-                           {
-        {
-            std::lock_guard<std::mutex> lock{mutex};
-            progress(assigned++);
-        }
-        size_t n = 0; // term number within document---constructed
-                      // so that each occurrence of the same term
-                      // can still be assigned a different topic
-        for (const auto& freq : idx_->search_primary(i)->counts())
-        {
-            for (size_t j = 0; j < freq.second; ++j)
+    parallel::parallel_for(
+        docs_.begin(), docs_.end(), pool_, [&](learn::instance& doc) {
             {
-                auto old_topic = doc_word_topic_[i][n];
-                // don't include current topic assignment in
-                // probability calculation
-                if (!init)
-                    decrease_counts(old_topic, freq.first, i);
-
-                // sample a new topic assignment
-                auto topic = sample_topic(freq.first, i);
-                doc_word_topic_[i][n] = topic;
-
-                // increase counts
-                increase_counts(topic, freq.first, i);
-                n += 1;
+                std::lock_guard<std::mutex> lock{mutex};
+                progress(assigned++);
             }
-        }
-    });
+            size_t n = 0; // term number within document---constructed
+                          // so that each occurrence of the same term
+                          // can still be assigned a different topic
+            for (const auto& freq : doc.weights)
+            {
+                for (size_t j = 0; j < freq.second; ++j)
+                {
+                    auto old_topic = doc_word_topic_[doc.id][n];
+                    // don't include current topic assignment in
+                    // probability calculation
+                    if (!init)
+                        decrease_counts(old_topic, freq.first, doc.id);
+
+                    // sample a new topic assignment
+                    auto topic = sample_topic(freq.first, doc.id);
+                    doc_word_topic_[doc.id][n] = topic;
+
+                    // increase counts
+                    increase_counts(topic, freq.first, doc.id);
+                    n += 1;
+                }
+            }
+        });
 
     // reduce down the distribution diffs for phi into the global
     // distributions for phi
@@ -83,7 +80,7 @@ void parallel_lda_gibbs::perform_iteration(uint64_t iter,
 }
 
 void parallel_lda_gibbs::decrease_counts(topic_id topic, term_id term,
-                                         doc_id doc)
+                                         learn::instance_id doc)
 {
     auto tid = std::this_thread::get_id();
     phi_diffs_[tid][topic].decrement(term, 1);
@@ -91,14 +88,15 @@ void parallel_lda_gibbs::decrease_counts(topic_id topic, term_id term,
 }
 
 void parallel_lda_gibbs::increase_counts(topic_id topic, term_id term,
-                                         doc_id doc)
+                                         learn::instance_id doc)
 {
     auto tid = std::this_thread::get_id();
     phi_diffs_[tid][topic].increment(term, 1);
     theta_[doc].increment(topic, 1);
 }
 
-double parallel_lda_gibbs::compute_sampling_weight(term_id term, doc_id doc,
+double parallel_lda_gibbs::compute_sampling_weight(term_id term,
+                                                   learn::instance_id doc,
                                                    topic_id topic) const
 {
     auto tid = std::this_thread::get_id();

--- a/src/topics/parallel_lda_gibbs.cpp
+++ b/src/topics/parallel_lda_gibbs.cpp
@@ -40,7 +40,7 @@ void parallel_lda_gibbs::perform_iteration(uint64_t iter,
     std::mutex mutex;
     uint64_t assigned = 0;
     parallel::parallel_for(
-        docs_.begin(), docs_.end(), pool_, [&](learn::instance& doc) {
+        docs_.begin(), docs_.end(), pool_, [&](const learn::instance& doc) {
             {
                 std::lock_guard<std::mutex> lock{mutex};
                 progress(assigned++);

--- a/src/topics/tools/lda_topics.cpp
+++ b/src/topics/tools/lda_topics.cpp
@@ -8,7 +8,6 @@
 #include <string>
 #include <vector>
 
-#include "meta/caching/no_evict_cache.h"
 #include "meta/index/forward_index.h"
 #include "meta/util/fixed_heap.h"
 
@@ -28,8 +27,7 @@ int print_topics(const std::string& config_file, const std::string& filename,
                  size_t num_words)
 {
     auto config = cpptoml::parse_file(config_file);
-    auto idx = index::make_index<index::forward_index, caching::no_evict_cache>(
-        *config);
+    auto idx = index::make_index<index::forward_index>(*config);
 
     std::ifstream file{filename};
     while (file)

--- a/src/topics/tools/topic_corpus.cpp
+++ b/src/topics/tools/topic_corpus.cpp
@@ -20,7 +20,7 @@ int print_usage(const std::string& name)
 {
     std::cerr
         << "Usage: " << name
-        << " config_file model.theta\n"
+        << " config.toml model.theta\n"
            "\tCreates a line_corpus dataset based on the topics from an LDA run"
         << std::endl;
     return 1;

--- a/tests/topics_test.cpp
+++ b/tests/topics_test.cpp
@@ -6,9 +6,9 @@
 #include <fstream>
 
 #include "bandit/bandit.h"
-#include "meta/caching/no_evict_cache.h"
 #include "create_config.h"
 #include "meta/index/forward_index.h"
+#include "meta/learn/dataset.h"
 #include "meta/topics/lda_gibbs.h"
 #include "meta/topics/parallel_lda_gibbs.h"
 #include "meta/topics/lda_cvb.h"
@@ -19,29 +19,32 @@ using namespace meta;
 
 namespace {
 
-template <class TopicModel, class ForwardIndex>
-void run_model(const ForwardIndex& idx, const std::string& prefix) {
+template <class TopicModel>
+void run_model(const learn::dataset& docs, const std::string& prefix) {
     {
         const double delta = 0.0000001;
         const uint64_t num_topics = 3;
-        TopicModel model{idx, num_topics, 0.1, 0.1}; // alpha = beta = 0.1
+        TopicModel model{docs, num_topics, 0.1, 0.1}; // alpha = beta = 0.1
         AssertThat(model.num_topics(), Equals(num_topics));
         model.run(3); // only run for three iterations
 
         // all term probs for all topics should sum to 1
         for (uint64_t topic = 0; topic < model.num_topics(); ++topic) {
             double sum = 0.0;
-            for (uint64_t term = 0; term < idx->unique_terms(); ++term)
+            for (uint64_t term = 0; term < docs.total_features(); ++term)
+            {
                 sum += model.compute_term_topic_probability(term_id{term},
                                                             topic_id{topic});
+            }
             AssertThat(sum, EqualsWithDelta(1.0, delta));
         }
 
         // all topic probs for all docs should sum to 1
-        for (const auto& d_id : idx->docs()) {
+        for (const auto& doc : docs)
+        {
             double sum = 0.0;
             for (uint64_t topic = 0; topic < model.num_topics(); ++topic)
-                sum += model.compute_doc_topic_probability(d_id,
+                sum += model.compute_doc_topic_probability(doc.id,
                                                            topic_id{topic});
             AssertThat(sum, EqualsWithDelta(1.0, delta));
         }
@@ -59,21 +62,21 @@ go_bandit([]() {
     describe("[topics]", [&]() {
         const std::string prefix = "meta-test-lda-model";
         auto config = tests::create_config("line");
-        auto idx
-            = index::make_index<index::forward_index, caching::no_evict_cache>(
-                *config);
+        auto idx = index::make_index<index::forward_index>(*config);
+        auto doc_list = idx->docs();
+        learn::dataset docs{idx, doc_list.begin(), doc_list.end()};
 
         it("should run LDA with CVB inference",
-           [&]() { run_model<topics::lda_cvb>(idx, prefix); });
+           [&]() { run_model<topics::lda_cvb>(docs, prefix); });
 
         it("should run LDA with Gibbs sampling inference",
-           [&]() { run_model<topics::lda_gibbs>(idx, prefix); });
+           [&]() { run_model<topics::lda_gibbs>(docs, prefix); });
 
         it("should run LDA with SCVB0 inference",
-           [&]() { run_model<topics::lda_scvb>(idx, prefix); });
+           [&]() { run_model<topics::lda_scvb>(docs, prefix); });
 
         it("should run LDA with parallel Gibbs inference",
-           [&]() { run_model<topics::parallel_lda_gibbs>(idx, prefix); });
+           [&]() { run_model<topics::parallel_lda_gibbs>(docs, prefix); });
     });
 
     filesystem::remove_all("ceeaus");


### PR DESCRIPTION
PR for easier conversation.

Changes
- removed uses of `no_evict_cache`
- use `dataset_view` internally in `lda_scvb` to manage the minibatch shuffling

Things that could be added:
- making `doc_size` a function of `instance` or `dataset`; or just leaving as a helper function in `lda_model`
- constructor for `dataset` that takes a single `{inverted,forward}_index` parameter and automatically uses the whole document range