### PR TITLE
Add fix for failing ICU download url 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/deps/meta-cmake/)
 
 FindOrBuildICU(
   VERSION 63.1
-  URL http://download.icu-project.org/files/icu4c/63.1/icu4c-63_1-src.tgz
+  URL https://github.com/unicode-org/icu/releases/download/release-63-1/icu4c-63_1-src.tgz
   URL_HASH SHA512=9ab407ed840a00cdda7470dcc4c40299a125ad246ae4d019c4b1ede54781157fd63af015a8228cd95dbc47e4d15a0932b2c657489046a19788e5e8266eac079c
 )
 


### PR DESCRIPTION
Add updated ICU download URL after ICU dependency's tgz file was migrated from Subversion repo to GitHub repo (source: http://site.icu-project.org/repository). 

Purpose: Meta's cmake steps will fail to download the ICU dependency because the old URL for the ICU dependency does not have the Tar file anymore. Without this updated URL that has the ICU dependency Meta needs to build, no-one can make builds of Meta. 