### PR TITLE
Add udpated URL for ICU dependency.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/deps/meta-cmake/)
 
 FindOrBuildICU(
   VERSION 58.2
-  URL http://download.icu-project.org/files/icu4c/58.2/icu4c-58_2-src.tgz
+  URL https://github.com/unicode-org/icu/releases/download/release-58-2/icu4c-58_2-src.tgz
   URL_HASH MD5=fac212b32b7ec7ab007a12dff1f3aea1
 )
 


### PR DESCRIPTION
Add updated ICU download URL after ICU dependency's tgz file was migrated from Subversion repo to GitHub repo (source: http://site.icu-project.org/repository).

Purpose: Metapy's Python wheel install process runs the Meta repo's cmake build process. The Meta repo's cmake steps will fail to download the ICU dependency because the old URL for the ICU dependency does not have the Tar file anymore. Without this updated URL that has the ICU dependency Meta needs to build, no-one can make builds of Meta and by extension, the Metapy repo cannot make new builds for Python 3.8 and Python 3.9 which are currently needed (but missing because of this bug).